### PR TITLE
Add Exchange to Deployment

### DIFF
--- a/docker-deploy/docker-compose-exchange.yml
+++ b/docker-deploy/docker-compose-exchange.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  exchange:
+    image: "${PREFIX}/proxy:${TAG}"
+    ports:
+      - "9370:9370"
+    volumes:
+      - ./conf:/data/projects/fate/proxy/conf

--- a/docker-deploy/docker-compose.yml
+++ b/docker-deploy/docker-compose.yml
@@ -12,8 +12,8 @@ volumes:
 services:
   federation:
     image: "${PREFIX}/federation:${TAG}"
-    expose:
-      - 9394
+    ports:
+      - "9394:9394"
     volumes:
       - ./confs/federation/conf:/data/projects/fate/federation/conf
     networks:
@@ -22,7 +22,7 @@ services:
   proxy:
     image: "${PREFIX}/proxy:${TAG}"
     ports:
-      - "9370:9370"
+      - "9371:9370"
     volumes:
       - ./confs/proxy/conf:/data/projects/fate/proxy/conf
     networks:
@@ -30,8 +30,8 @@ services:
 
   serving-server:
     image: "${PREFIX}/serving-server:${TAG}"
-    expose:
-      - 8001
+    ports:
+      - "8001:8001"
     volumes:
       - ./confs/serving-server/conf:/data/projects/fate/serving-server/conf
     depends_on:
@@ -83,9 +83,9 @@ services:
 
   python:
     image: "${PREFIX}/python:${TAG}"
-    expose:
-      - 9360
-      - 9380
+    ports:
+      - "9360:9360"
+      - "9380:9380"
     restart: always
     volumes:
       - ./confs/python/arch/conf:/data/projects/fate/python/arch/conf

--- a/docker-deploy/docker-configuration.sh
+++ b/docker-deploy/docker-configuration.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-user=luke
+user=root
 dir=/data/projects/fate
-partylist=(3 4) 
-partyiplist=(10.160.102.71 10.161.41.191)
+partylist=(9999 10000) 
+partyiplist=(192.168.10.1 192.168.10.2)
 venvdir=/data/projects/fate/venv
 
 # party 1 will host the exchange by default

--- a/docker-deploy/docker-configuration.sh
+++ b/docker-deploy/docker-configuration.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-user=root
+user=luke
 dir=/data/projects/fate
-partylist=(10000) 
-partyiplist=(0.0.0.0)
+partylist=(3 4) 
+partyiplist=(10.160.102.71 10.161.41.191)
 venvdir=/data/projects/fate/venv
-exchangeip=proxy
+
+# party 1 will host the exchange by default
+exchangeip=${partyiplist[0]}
+

--- a/docker-deploy/docker-example-dir-tree/fateboard/conf/application.properties
+++ b/docker-deploy/docker-example-dir-tree/fateboard/conf/application.properties
@@ -1,5 +1,5 @@
 server.port=8080
-fate.url=http://python:9380
+fateflow.url=http://python:9380
 spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 management.endpoints.web.exposure.include=*
 spring.http.encoding.charset=UTF-8

--- a/docker-deploy/docker-example-dir-tree/python/modify_json.py
+++ b/docker-deploy/docker-example-dir-tree/python/modify_json.py
@@ -20,7 +20,7 @@ def get_new_json(module_name,filepath):
 		json_data = json.load(f)
 		a = json_data
 		if module_name == "exchange":
-			a["route_table"][partyId]={"default":[{"ip": pip,"port": 9370}]}
+			a["route_table"][partyId]={"default":[{"ip": pip,"port": 9371}]}
 		elif module_name == "proxy":
 			a["route_table"]={"default":{"default":[{"ip": exchangeip,"port": 9370}]},\
 			partyId:{"fate":[{"ip": fip,"port": 9394}],"fateflow":[{"ip": flip,"port": 9360}]}}


### PR DESCRIPTION
This patch removes the info of other parties from the proxy's route
table. Instead, an `exchange` is added to maintain the entry point of
all parties, so that any party could find out another party through
exchange easily.

1. update `docker-auto-deploy.sh` to handle the deployment of exchange. By
default, the exchange will be deployed on the first party defined in
`partylist`.

2. update fate_flow's properties

Signed-off-by: jiahaoc <jiahaoc@vmware.com>

Fixes  ISSUE#xxx

Changes:

1.

2.

3.


