### PR TITLE
Deprecated the git clone way to get KubeFATE.

### DIFF
--- a/docker-deploy/README.md
+++ b/docker-deploy/README.md
@@ -13,10 +13,8 @@ The nodes (target nodes) to install FATE must meet the following requirements:
 ## Deploying FATE
 A Linux host can be used as a deployment machine to run installation scripts to deploy FATE onto target hosts.
 
-First, on a Linux host, clone KubeFATE source repo:
-```bash
-$ git clone git@github.com:FederatedAI/KubeFATE.git
-```
+First, on a Linux host, download KubeFATE from [releases pages](https://github.com/FederatedAI/KubeFATE/releases), unzip it into folder KubeFATE.
+
 By default, the installation script pulls the images from Docker Hub during the deployment. If the target node is not connected to Internet, refer to the below section to set up a local registry such as Harbor and use the offline images.
 
 ### Set up a local registry Harbor (Optional)

--- a/docker-deploy/README_zh.md
+++ b/docker-deploy/README_zh.md
@@ -55,11 +55,8 @@ mysql                              8
 ```
 ### 下载部署脚本
 
-部署机器运行以下命令获取kubeFATE项目代码：
+在部署机器上下载合适的KubeFATE版本，可参考 [releases pages](https://github.com/FederatedAI/KubeFATE/releases)，然后解压到KubeFATE目录。
 
-```bash
-git clone git@github.com:FederatedAI/KubeFATE.git
-```
 
 ### 修改镜像配置文件
 

--- a/k8s-deploy/README.md
+++ b/k8s-deploy/README.md
@@ -31,10 +31,7 @@ python         | fateflow.\<namespace><br/>fateboard.\<namespace> | fate-flow/fa
 The Helm is a package management tool of Kubernetes, it simplifies the deployment and management of applications on Kubernetes. Before using the script, a user needs to install on his machine first. For more details about Helm and installation please refer to the [official page](https://helm.sh/docs/using_helm/).
 
 ## Deploying FATE
-Use the following command to clone repo if you did not clone before: 
-```bash
-$ git clone git@github.com:FederatedAI/KubeFATE.git
-```
+Download KubeFATE from [releases pages](https://github.com/FederatedAI/KubeFATE/releases), unzip it into folder KubeFATE
 
 By default, the script pulls the images from [Docker Hub](https://hub.docker.com/search?q=federatedai&type=image) during the deployment.
 

--- a/k8s-deploy/README_zh.md
+++ b/k8s-deploy/README_zh.md
@@ -36,10 +36,7 @@ python         | fateflow.\<namespace><br>fateboard.\<namespace> | fate-flow/fat
 
 ## 克隆KubeFATE项目
 
-通过以下命令克隆远端代码块：
-```bash
-$ git clone git@github.com:FederatedAI/KubeFATE.git
-```
+请在 [releases pages](https://github.com/FederatedAI/KubeFATE/releases)中下载合适的KubeFATE版本，并解压到KubeFATE目录
 
 ## 使用第三方Docker仓库
 非互联网集群建议使用[Harbor](https://goharbor.io/)作为第三方仓库。安装Harbor请参考[文章](https://github.com/FederatedAI/KubeFATE/blob/master/registry/install_harbor.md)。在`.env`文件中，将`THIRDPARTYPREFIX`更改为Harbor的IP。 192.168.10.1是Harbor IP的示例。


### PR DESCRIPTION
Signed-off-by: Layne Peng <playne@vmware.com>

Deprecated the git clone way to get KubeFATE

Changes:

1.  Totally change the introduction of four README files.

