### PR TITLE
Istio support

### DIFF
--- a/fate-serving/templates/data-nfs.yaml
+++ b/fate-serving/templates/data-nfs.yaml
@@ -1,7 +1,13 @@
-########################################################
-# Copyright 2019-2020 program was created VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 {{- if and .Values.nfspath (.Values.nfsserver) }}
 apiVersion: v1

--- a/fate-serving/templates/ingress.yaml
+++ b/fate-serving/templates/ingress.yaml
@@ -1,7 +1,13 @@
-########################################################
-# Copyright 2019-2020 program was created VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 {{ if .Values.servingProxy.include }}
 apiVersion: extensions/v1beta1

--- a/fate-serving/templates/istio.yaml
+++ b/fate-serving/templates/istio.yaml
@@ -1,0 +1,59 @@
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+{{ if .Values.istio.enabled }}
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+    name: {{ .Values.partyName }}-gateway
+    # namespace: {{.Namespace}}
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80 
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: fate-serving-ingress
+  labels:
+      fateMoudle: serving-proxy
+      name: {{ .Values.partyName | quote  }}
+      partyId: {{ .Values.partyId | quote  }}
+      owner: kubefate
+      cluster: fate
+  # namespace: {{.Namespace}}
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - {{ .Values.partyName }}-gateway
+  http:
+{{ if .Values.servingProxy.include }}
+  - match:
+    - uri:
+        prefix: /serving-proxy-{{ .Values.partyId }}
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: serving-proxy.{{ .Values.partyName }}.svc.cluster.local
+        port:
+          number: 8059 
+{{ end }}
+
+{{ end }}

--- a/fate-serving/templates/serving-proxy-module.yaml
+++ b/fate-serving/templates/serving-proxy-module.yaml
@@ -1,7 +1,13 @@
-########################################################
-# Copyright 2019-2020 program was created VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 {{ if .Values.servingProxy.include }}
 kind: ConfigMap

--- a/fate-serving/templates/serving-redis-module.yaml
+++ b/fate-serving/templates/serving-redis-module.yaml
@@ -1,7 +1,13 @@
-########################################################
-# Copyright 2019-2020 program was created VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 {{ if .Values.servingRedis.include }}
 kind: ConfigMap

--- a/fate-serving/templates/serving-server-module.yaml
+++ b/fate-serving/templates/serving-server-module.yaml
@@ -1,7 +1,13 @@
-########################################################
-# Copyright 2019-2020 program was created VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 {{ if .Values.servingServer.include }}
 kind: ConfigMap
@@ -31,6 +37,7 @@ data:
     # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     # See the License for the specific language governing permissions and
     # limitations under the License.
+
     #
     ip=127.0.0.1
     port=8000

--- a/fate-serving/values-template-example.yaml
+++ b/fate-serving/values-template-example.yaml
@@ -48,3 +48,6 @@ externalRedisIp: serving-redis
 externalRedisPort: 6379
 externalRedisDatabase: 0
 externalRedisPassword: fate_dev
+
+istio:
+  enabled: false

--- a/fate-serving/values-template.yaml
+++ b/fate-serving/values-template.yaml
@@ -131,3 +131,6 @@ servingServer:
   accessMode: ReadWriteOnce
   size: 1Gi
 {{- end }}
+
+istio:
+  enabled: {{ .istio.enabled | default false }

--- a/fate-serving/values.yaml
+++ b/fate-serving/values.yaml
@@ -54,3 +54,5 @@ servingServer:
   accessMode: ReadWriteOnce
   size: 1Gi
 
+istio:
+  enabled: false

--- a/fate/templates/NOTES.txt
+++ b/fate/templates/NOTES.txt
@@ -1,3 +1,8 @@
 Please wait for several minutes for FATE deployment to complete.
 Then you should be able to visit the FateBoard portal at {{ .Values.host.fateboard }} and NoteBook portal at {{ .Values.host.client }}.
 For more details, please visit https://github.com/FederatedAI/KubeFATE.
+
+# optional
+If you have enabled the istio, please visit:
+- FateBoard at http://${istio-gateway}/fateboard-{{ .Values.partyId }}/
+- NoteBook at http://${istio-gateway}/notebook-{{ .Values.partyId }}/ 

--- a/fate/templates/clustermanager-module.yaml
+++ b/fate/templates/clustermanager-module.yaml
@@ -1,7 +1,13 @@
-########################################################
-# Copyright 2019-2020 program was created VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 {{ if .Values.modules.clustermanager.include }}
 apiVersion: apps/v1

--- a/fate/templates/eggroll-config.yaml
+++ b/fate/templates/eggroll-config.yaml
@@ -1,7 +1,13 @@
-########################################################
-# Copyright 2019-2020 program was created VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 kind: ConfigMap
 apiVersion: v1

--- a/fate/templates/ingress.yaml
+++ b/fate/templates/ingress.yaml
@@ -1,7 +1,13 @@
-########################################################
-# Copyright 2019-2020 program was created VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 {{ if .Values.modules.python.include }}
 apiVersion: extensions/v1beta1

--- a/fate/templates/ingress.yaml
+++ b/fate/templates/ingress.yaml
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{ if eq .Values.host.ingressType "nginx"}}
 {{ if .Values.modules.python.include }}
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -47,5 +46,4 @@ spec:
           serviceName: notebook
           servicePort: 20000
 ---
-{{ end }}
 {{ end }}

--- a/fate/templates/ingress.yaml
+++ b/fate/templates/ingress.yaml
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+{{ if eq .Values.host.ingressType "nginx"}}
 {{ if .Values.modules.python.include }}
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -47,4 +47,5 @@ spec:
           serviceName: notebook
           servicePort: 20000
 ---
+{{ end }}
 {{ end }}

--- a/fate/templates/istio.yaml
+++ b/fate/templates/istio.yaml
@@ -49,6 +49,61 @@ spec:
         host: fateboard.{{ .Values.partyName }}.svc.cluster.local
         port:
           number: 8080
+  - match:
+    - headers:
+        referer:
+          regex: .*\/fateboard-{{ .Values.partyId }}\/$
+      uri:
+        prefix: /queryLogSize
+    route:
+    - destination:
+        host: fateboard.{{ .Values.partyName }}.svc.cluster.local
+        port:
+          number: 8080
+  - match:
+    - headers:
+        referer:
+          regex: .*\/fateboard-{{ .Values.partyId }}\/$
+      uri:
+        prefix: /v1
+    route:
+    - destination:
+        host: fateboard.{{ .Values.partyName }}.svc.cluster.local
+        port:
+          number: 8080
+  - match:
+    - headers:
+        referer:
+          regex: .*\/fateboard-{{ .Values.partyId }}\/$
+      uri:
+        prefix: /ssh
+    route:
+    - destination:
+        host: fateboard.{{ .Values.partyName }}.svc.cluster.local
+        port:
+          number: 8080
+  - match:
+    - headers:
+        referer:
+          regex: .*\/fateboard-{{ .Values.partyId }}\/$
+      uri:
+        prefix: /log
+    route:
+    - destination:
+        host: fateboard.{{ .Values.partyName }}.svc.cluster.local
+        port:
+          number: 8080
+  - match:
+    - headers:
+        referer:
+          regex: .*\/fateboard-{{ .Values.partyId }}\/$
+      uri:
+        prefix: /job
+    route:
+    - destination:
+        host: fateboard.{{ .Values.partyName }}.svc.cluster.local
+        port:
+          number: 8080
 {{ end }}
 {{ if .Values.modules.client.include }}  
   - match:

--- a/fate/templates/istio.yaml
+++ b/fate/templates/istio.yaml
@@ -1,0 +1,65 @@
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+{{ if eq .Values.host.ingressType "istio"}}
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+    name: {{ .Values.partyName }}-gateway
+    # namespace: {{.Namespace}}
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80 
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: fate-ingress 
+  labels:
+{{ include "fate.labels" . | indent 4 }}
+  # namespace: {{.Namespace}}
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - {{ .Values.partyName }}-gateway
+  http:
+{{ if .Values.modules.python.include }} 
+  - match:
+    - uri:
+        prefix: /fateboard-{{ .Values.partyId }}
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fateboard.{{ .Values.partyName }}.svc.cluster.local
+        port:
+          number: 8080
+{{ end }}
+{{ if .Values.modules.client.include }}  
+  - match:
+    - uri:
+        prefix: /client-{{ .Values.partyId }}
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: notebook.{{ .Values.partyName }}.svc.cluster.local
+        port:
+            number: 20000
+{{ end }}
+{{ end }}

--- a/fate/templates/istio.yaml
+++ b/fate/templates/istio.yaml
@@ -8,7 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-{{ if eq .Values.host.ingressType "istio"}}
+{{ if .Values.istio.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:

--- a/fate/templates/mysql-module.yaml
+++ b/fate/templates/mysql-module.yaml
@@ -1,7 +1,13 @@
-########################################################
-# Copyright 2019-2020 program was created VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 {{ if .Values.modules.mysql.include }}
 apiVersion: v1

--- a/fate/templates/nodemanager-module.yaml
+++ b/fate/templates/nodemanager-module.yaml
@@ -1,7 +1,13 @@
-########################################################
-# Copyright 2019-2020 program was created VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 {{- if .Values.modules.nodemanager.include }}

--- a/fate/templates/python-module.yaml
+++ b/fate/templates/python-module.yaml
@@ -1,7 +1,13 @@
-########################################################
-# Copyright 2019-2020 program was created VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 {{ if .Values.modules.python.include }}
 kind: ConfigMap

--- a/fate/templates/rollsite-module.yaml
+++ b/fate/templates/rollsite-module.yaml
@@ -1,7 +1,13 @@
-########################################################
-# Copyright 2019-2020 program was created VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2020 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 {{ if .Values.modules.rollsite.include }}
 kind: ConfigMap

--- a/fate/values-template-example.yaml
+++ b/fate/values-template-example.yaml
@@ -5,6 +5,7 @@ chartVersion: v1.4.0
 partyId: 10000
 registry: ""
 pullPolicy: 
+ingressType: istio
 persistence: false
 modules:
   - rollsite

--- a/fate/values-template-example.yaml
+++ b/fate/values-template-example.yaml
@@ -5,8 +5,8 @@ chartVersion: v1.4.0
 partyId: 10000
 registry: ""
 pullPolicy: 
-ingressType: nginx 
 persistence: false
+enableIstio: false
 modules:
   - rollsite
   - clustermanager

--- a/fate/values-template-example.yaml
+++ b/fate/values-template-example.yaml
@@ -6,7 +6,8 @@ partyId: 10000
 registry: ""
 pullPolicy: 
 persistence: false
-enableIstio: false
+istio:
+  enabled: false
 modules:
   - rollsite
   - clustermanager

--- a/fate/values-template-example.yaml
+++ b/fate/values-template-example.yaml
@@ -5,7 +5,7 @@ chartVersion: v1.4.0
 partyId: 10000
 registry: ""
 pullPolicy: 
-ingressType: istio
+ingressType: nginx 
 persistence: false
 modules:
   - rollsite

--- a/fate/values-template.yaml
+++ b/fate/values-template.yaml
@@ -9,6 +9,7 @@ partyId: {{ .partyId }}
 partyName: {{ .name }}
 
 host:
+  ingressType: {{ .ingressType | default "nginx" }}
   fateboard: {{ .partyId }}.fateboard.kubefate.net
   client: {{ .partyId }}.notebook.kubefate.net
 

--- a/fate/values-template.yaml
+++ b/fate/values-template.yaml
@@ -9,11 +9,13 @@ partyId: {{ .partyId }}
 partyName: {{ .name }}
 
 host:
-  ingressType: {{ .ingressType | default "nginx" }}
   fateboard: {{ .partyId }}.fateboard.kubefate.net
   client: {{ .partyId }}.notebook.kubefate.net
 
 nodePort: {{ with .rollsite }}{{ .nodePort }}{{ end }}
+
+istio:
+  enabled: {{ .enableIstio | default false }}
 
 exchange:
 {{- with .rollsite }}

--- a/fate/values-template.yaml
+++ b/fate/values-template.yaml
@@ -15,7 +15,7 @@ host:
 nodePort: {{ with .rollsite }}{{ .nodePort }}{{ end }}
 
 istio:
-  enabled: {{ .enableIstio | default false }}
+  enabled: {{ .istio.enabled | default false }}
 
 exchange:
 {{- with .rollsite }}

--- a/fate/values.yaml
+++ b/fate/values.yaml
@@ -8,8 +8,10 @@ image:
 partyId: 9999
 partyName: fate-9999
 
+istio:
+  enabled: false
+
 host:
-  ingressType: nginx 
   fateboard: 9999.fateboard.kubefate.net
   client: 9999.notebook.kubefate.net
 

--- a/fate/values.yaml
+++ b/fate/values.yaml
@@ -9,7 +9,7 @@ partyId: 9999
 partyName: fate-9999
 
 host:
-  ingressType: istio 
+  ingressType: nginx 
   fateboard: 9999.fateboard.kubefate.net
   client: 9999.notebook.kubefate.net
 

--- a/fate/values.yaml
+++ b/fate/values.yaml
@@ -9,6 +9,7 @@ partyId: 9999
 partyName: fate-9999
 
 host:
+  ingressType: istio 
   fateboard: 9999.fateboard.kubefate.net
   client: 9999.notebook.kubefate.net
 


### PR DESCRIPTION
The consideration is the virtual service of Istio may exist together with the nginx ingress rule. So a feature flag was added to enable the Istio, but the nginx rule will be created for the fateboard and client service by default.

Works:
1.  Add virtual service template to support Istio
2. Update `NOTE` to inform the way to access virtual service(if Istio is enabled)
3. Update open source headers