### PR TITLE
Fix the missing of download_dir

### DIFF
--- a/docker-deploy/training_template/docker-compose.yml
+++ b/docker-deploy/training_template/docker-compose.yml
@@ -119,6 +119,8 @@ services:
     environment:
       FATE_FLOW_HOST: "python:9380"
       FATE_SERVING_HOST: "fate-serving:8059"
+    volumes:
+      - download_dir:/fml_manager/Examples/download_dir
     depends_on:
       - python
     networks:


### PR DESCRIPTION
Fix the missing of `download_dir` in client container

Signed-off-by: jiahaoc <jiahaoc@vmware.com>

