### PR TITLE
fix: docker build error 

### DIFF
--- a/k8s-deploy/Dockerfile
+++ b/k8s-deploy/Dockerfile
@@ -9,6 +9,7 @@ RUN go mod download
 
 COPY kubefate.go kubefate.go
 COPY pkg/ pkg/
+COPY docs/docs.go docs/docs.go 
 COPY config.yaml config.yaml
 
 ARG LDFLAGS


### PR DESCRIPTION
error: `build command-line-arguments: cannot load github.com/FederatedAI/KubeFATE/k8s-deploy/docs: module github.com/FederatedAI/KubeFATE@latest found (v1.5.0), but does not contain package github.com/FederatedAI/KubeFATE/k8s-deploy/docs`

Signed-off-by: ChenLong Ma <owlet42@126.com>