### PR TITLE
Update chart to support python-nn for k8s-deploy

### DIFF
--- a/docs/configurations/FATE_cluster_configuration.md
+++ b/docs/configurations/FATE_cluster_configuration.md
@@ -111,6 +111,7 @@ The parties are directly connected.
 | type                 | scalars  | Kubernetes ServiceTypes, default is NodePort.<br />Other modules can connect to the fateflow |
 | nodePort             | scalars  | The port used by `proxy` module's kubernetes service, default range: 30000-32767. |
 | nodeSelector         | mappings | kubernetes nodeSelector.                                     |
+| enabled_nn           | bool     | If or not neural network workflow is required                |
 | spark                | mappings | If you use your own spark, modify the configuration          |
 | spark.master         | scalars  | If you do not need to use the spark configuration, you can use the spark configuration |
 | spark.home           | scalars  | configuration of FATE fateflow module                        |

--- a/helm-charts/FATE/Chart.yaml
+++ b/helm-charts/FATE/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.5.1
 description: A Helm chart for fate-training
 name: fate
-version: v1.5.1
+version: v1.5.1-a
 home: https://fate.fedai.org
 icon: https://aisp-1251170195.cos.ap-hongkong.myqcloud.com/wp-content/uploads/sites/12/2019/09/logo.png
 sources:

--- a/helm-charts/FATE/templates/python-spark.yaml
+++ b/helm-charts/FATE/templates/python-spark.yaml
@@ -219,7 +219,7 @@ spec:
           {{- if eq .Values.modules.python.backend  "spark" }}
           image: {{ .Values.image.registry }}/python-spark:{{ .Values.image.tag }}
           {{- else }}
-          image: {{ .Values.image.registry }}/python:{{ .Values.image.tag }}
+          image: {{ .Values.image.registry }}/{{ if .Values.modules.python.enabled_nn }}python-nn{{ else }}python{{ end }}:{{ .Values.image.tag }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -75,7 +75,8 @@ backend: eggroll
   # type: NodePort
   # httpNodePort: 30097
   # grpcNodePort: 30092
-  # nodeSelector: 
+  # nodeSelector:
+  # enabled_nn: false
   # spark: 
     # master: spark://spark-master:7077
     # home: 

--- a/helm-charts/FATE/values-template.yaml
+++ b/helm-charts/FATE/values-template.yaml
@@ -100,6 +100,7 @@ modules:
     nodeSelector: 
 {{ toYaml . | indent 6 }}
     {{- end }}
+    enabled_nn: {{ .enabled_nn | default false }}
     {{- with .spark }}
     spark: 
       master: {{ .master }}

--- a/helm-charts/FATE/values.yaml
+++ b/helm-charts/FATE/values.yaml
@@ -59,6 +59,7 @@ modules:
     grpcNodePort: 30092
     nodeSelector: 
     backend: eggroll
+    enabled_nn: false
     spark: 
       master: spark://spark-master:7077
       home: 

--- a/k8s-deploy/cluster.yaml
+++ b/k8s-deploy/cluster.yaml
@@ -64,7 +64,8 @@ backend: eggroll
   # type: NodePort
   # httpNodePort: 30097
   # grpcNodePort: 30092
-  # nodeSelector: 
+  # nodeSelector:
+  # enabled_nn: false
   # spark: 
     # master: spark://spark-master:7077
     # home: 


### PR DESCRIPTION
Add support of python-nn by adding one more item in the cluster
configuration and plumb it through down to the chart template.

Signed-off-by: Fangchi Wang <wfangchi@vmware.com>