### PR TITLE
Execute ReadInConfig before init logger

### DIFF
--- a/k8s-deploy/kubefate.go
+++ b/k8s-deploy/kubefate.go
@@ -27,11 +27,12 @@ import (
 
 func main() {
 	config.InitViper()
-	logging.InitLog()
 	err := viper.ReadInConfig()
 	if err != nil {
 		log.Debug().Err(err).Msg("load config.yaml error")
 	}
+
+	logging.InitLog()
 
 	err = cli.Run(os.Args)
 	if err != nil {

--- a/k8s-deploy/kubefate.go
+++ b/k8s-deploy/kubefate.go
@@ -21,7 +21,6 @@ import (
 	"github.com/FederatedAI/KubeFATE/k8s-deploy/pkg/cli"
 	"github.com/FederatedAI/KubeFATE/k8s-deploy/pkg/utils/config"
 	"github.com/FederatedAI/KubeFATE/k8s-deploy/pkg/utils/logging"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 )
 
@@ -29,7 +28,8 @@ func main() {
 	config.InitViper()
 	err := viper.ReadInConfig()
 	if err != nil {
-		log.Debug().Err(err).Msg("load config.yaml error")
+		fmt.Println("load config.yaml error,", err)
+		os.Exit(1)
 	}
 
 	logging.InitLog()

--- a/k8s-deploy/pkg/utils/config/config.go
+++ b/k8s-deploy/pkg/utils/config/config.go
@@ -39,6 +39,8 @@ func InitViper() {
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
 
+	viper.ReadInConfig()
+
 	return
 }
 

--- a/k8s-deploy/pkg/utils/config/config.go
+++ b/k8s-deploy/pkg/utils/config/config.go
@@ -39,8 +39,6 @@ func InitViper() {
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
 
-	viper.ReadInConfig()
-
 	return
 }
 


### PR DESCRIPTION
Read config into viper before init logger.
So that `	logging.InitLog()` can read configurations from `configs.yaml`
Right now `InitLog` can not get log level parameter inside the `configs.yaml`, cause the `InitLog` is executed before viper read the `configs.yaml`
