### PR TITLE
Fix: issue #372 解决kubefate linux兼容性问题

### DIFF
--- a/k8s-deploy/Makefile
+++ b/k8s-deploy/Makefile
@@ -26,7 +26,7 @@ test: fmt vet
 
 # Build manager binary
 kubefate: fmt vet swag
-	go build -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
+	CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
 
 run: fmt vet 
 	go run ./kubefate.go service


### PR DESCRIPTION
Fixes  ISSUE#372

Changes:
1.  k8s-deploy/Makefile
 kubefate: fmt vet swag
-       go build -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
+       CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go


