### PR TITLE
fix: some mirrors cannot use the registry

### DIFF
--- a/helm-charts/FATE-Exchange/templates/traffic-server-module.yaml
+++ b/helm-charts/FATE-Exchange/templates/traffic-server-module.yaml
@@ -75,7 +75,7 @@ spec:
         cluster: fate-exchange
     spec:
       containers:
-        - image: shaker/trafficserver
+        - image: {{ .Values.image.registry }}/trafficserver
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: traffic-server
           ports:

--- a/helm-charts/FATE/templates/nodemanager-module.yaml
+++ b/helm-charts/FATE/templates/nodemanager-module.yaml
@@ -123,7 +123,11 @@ spec:
     spec:
       containers:
         - name: {{ $nodemanager.name }}-eggrollpair
-          image: fluent/fluentd:v1.11-debian-1
+        {{- if $root.Values.image.isThridParty }}
+          image: {{ $root.Values.image.registry }}/fluentd:v1.12
+        {{- else }}
+          image: fluent/fluentd:v1.12
+        {{- end }}
           volumeMounts:
           - name: eggroll-log
             mountPath: /data/projects/fate/eggroll/logs/

--- a/helm-charts/FATE/templates/rabbitmq.yaml
+++ b/helm-charts/FATE/templates/rabbitmq.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
         - name: rabbitmq
-          image: federatedai/rabbitmq:3.8.3-management
+          image: {{ .Values.image.registry }}/rabbitmq:3.8.3-management
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: RABBITMQ_DEFAULT_USER

--- a/k8s-deploy/Makefile
+++ b/k8s-deploy/Makefile
@@ -29,7 +29,7 @@ kubefate: fmt vet swag
 	CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
 
 kubefate-without-swag: fmt vet
-	go build -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
+	CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
 
 run: fmt vet 
 	go run ./kubefate.go service


### PR DESCRIPTION
- When using other sources, some images (rabbitmq, fluentd, trafficserver) cannot be downloaded.
- Fix make kubefate-without-swag