### PR TITLE
use tini to startup nodemanager

### DIFF
--- a/helm-charts/FATE/templates/nodemanager-module.yaml
+++ b/helm-charts/FATE/templates/nodemanager-module.yaml
@@ -149,7 +149,7 @@ spec:
             ln -sf /dev/stdout /data/projects/fate/eggroll/logs/eggroll/eggroll.jvm.log
             touch /data/projects/fate/eggroll/logs/eggroll/eggroll.jvm.err.log 
             ln -sf /dev/stderr /data/projects/fate/eggroll/logs/eggroll/eggroll.jvm.err.log
-            java -Dlog4j.configurationFile=$${EGGROLL_HOME}/conf/log4j2.properties -cp $${EGGROLL_HOME}/lib/*: com.webank.eggroll.core.Bootstrap --bootstraps com.webank.eggroll.core.resourcemanager.NodeManagerBootstrap -c $${EGGROLL_HOME}/conf/eggroll.properties -p 4671 -s 'EGGROLL_DEAMON'
+            /tini -- java -Dlog4j.configurationFile=$${EGGROLL_HOME}/conf/log4j2.properties -cp $${EGGROLL_HOME}/lib/*: com.webank.eggroll.core.Bootstrap --bootstraps com.webank.eggroll.core.resourcemanager.NodeManagerBootstrap -c $${EGGROLL_HOME}/conf/eggroll.properties -p 4671 -s 'EGGROLL_DEAMON'
           ports:
             - containerPort: 4671
           volumeMounts:


### PR DESCRIPTION
Fixes: to many defunct processes

After running training job, there will be lost of defunct process left。

![image](https://user-images.githubusercontent.com/2292716/114505230-a3934d80-9c62-11eb-8597-bb1657da438f.png)

To fix the problem，use tini to startup nodemanager
