### PR TITLE
Ignore nodeport when servingServer.type is not NodePort

### DIFF
--- a/helm-charts/FATE-Serving/templates/serving-server-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-server-module.yaml
@@ -151,8 +151,8 @@ spec:
     - name: "8000"
       port: 8000
       targetPort: 8000
-      {{- with .Values.servingServer.nodePort }}
-      nodePort: {{ . }}
+      {{- if eq .Values.servingServer.type "NodePort" "LoadBalancer" }}
+      nodePort: {{ .Values.servingServer.nodePort }}
       {{- end }}
       protocol: TCP
   type: {{ .Values.servingServer.type }}


### PR DESCRIPTION
if servingServer.type is not NodePort, nodeport should be ignored