### PR TITLE
feat: KubeFATE support PSP of Kubernetes

### DIFF
--- a/k8s-deploy/kubefate.yaml
+++ b/k8s-deploy/kubefate.yaml
@@ -86,6 +86,7 @@ spec:
       labels:
         fate: mariadb
     spec:
+      serviceAccountName: kubefate-admin
       containers:
         - image: mariadb:10
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
When deployed on k8s with PSP enabled, the pod of mariadb cannot be deployed because the default serviceAccount does not have PSP permissions.
Here, PSP permissions are given by assigning serviceAccount of mariadb kubefate-admin.
*'kubefate-admin' has the permissions of cluster-admin by default.*