### PR TITLE
fix: support router of FATE can update to pod

### DIFF
--- a/helm-charts/FATE-Exchange/templates/nginx.yaml
+++ b/helm-charts/FATE-Exchange/templates/nginx.yaml
@@ -137,12 +137,8 @@ spec:
             - containerPort: 9300
             - containerPort: 9310
           volumeMounts:
-            - mountPath: /data/projects/fate/proxy/nginx/conf/route_table.yaml
+            - mountPath: /data/projects/fate/proxy/nginx/conf
               name: nginx-confs
-              subPath: route_table.yaml
-            - mountPath: /data/projects/fate/proxy/nginx/conf/nginx.conf
-              name: nginx-confs
-              subPath: nginx.conf
       {{- with .Values.modules.nginx.nodeSelector }}
       nodeSelector: 
 {{ toYaml . | indent 8 }}

--- a/helm-charts/FATE-Exchange/templates/traffic-server-module.yaml
+++ b/helm-charts/FATE-Exchange/templates/traffic-server-module.yaml
@@ -21,12 +21,6 @@ metadata:
     owner: kubefate
     cluster: fate-exchange
 data:
-  sni.yaml: |
-    sni:
-    {{- range .Values.modules.trafficServer.route_table.sni }}
-      - fqdn: {{ .fqdn }}
-        tunnel_route: {{ .tunnelRoute }}
-    {{- end }}
   ssl_multicert.config: |
     dest_ip=* ssl_cert_name=proxy.cert.pem ssl_key_name=proxy.key.pem
   records.config: |
@@ -44,7 +38,26 @@ data:
     CONFIG proxy.config.ssl.CA.cert.path STRING /opt/proxy
     
     CONFIG proxy.config.ssl.server.cert.path STRING /opt/proxy
-
+    
+    CONFIG proxy.config.ssl.servername.filename STRING sni/sni.yaml
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: traffic-server-sni
+  labels:
+    fateMoudle: traffic-server
+    name: {{ .Values.partyName | quote  }}
+    partyId: {{ .Values.partyId | quote }}
+    owner: kubefate
+    cluster: fate-exchange
+data:
+  sni.yaml: |
+    sni:
+    {{- range .Values.modules.trafficServer.route_table.sni }}
+      - fqdn: {{ .fqdn }}
+        tunnel_route: {{ .tunnelRoute }}
+    {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -88,9 +101,8 @@ spec:
             - mountPath: /etc/trafficserver/ssl_multicert.config
               name: traffic-server-confs
               subPath: ssl_multicert.config
-            - mountPath: /opt/trafficserver/etc/trafficserver/sni.yaml
-              name: traffic-server-confs
-              subPath: sni.yaml
+            - mountPath: /opt/trafficserver/etc/trafficserver/sni
+              name: traffic-server-sni
             - mountPath: /opt/proxy
               name: traffic-server-cert-file
             - mountPath: /opt/trafficserver/etc/trafficserver/proxy.cert.pem
@@ -117,6 +129,9 @@ spec:
         - name: traffic-server-confs
           configMap:
             name: traffic-server-config
+        - name: traffic-server-sni
+          configMap:
+            name: traffic-server-sni
         - name: traffic-server-cert-file
           secret:
             secretName: traffic-server-cert

--- a/helm-charts/FATE-Serving/templates/serving-proxy-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-proxy-module.yaml
@@ -43,7 +43,7 @@ data:
     #inference.service.name=serving
     #random, consistent
     #routeType=random
-    #route.table=/data/projects/fate-serving/serving-proxy/conf/route_table.json
+    #route.table=/data/projects/fate-serving/serving-proxy/conf/route_table/route_table.json
     #auth.file=/data/projects/fate-serving/serving-proxy/conf/auth_config.json
     # zk router
     useZkRouter=true
@@ -155,9 +155,8 @@ spec:
             - mountPath: /data/projects/fate/serving-proxy/conf/application.properties
               name: serving-proxy-confs
               subPath: application.properties
-            - mountPath: /data/projects/fate/serving-proxy/conf/route_table.json
+            - mountPath: /data/projects/fate/serving-proxy/conf/route_table
               name: serving-proxy-confs
-              subPath: route_table.json
       {{- with .Values.servingProxy.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm-charts/FATE/templates/nginx.yaml
+++ b/helm-charts/FATE/templates/nginx.yaml
@@ -137,12 +137,8 @@ spec:
             - containerPort: 9300
             - containerPort: 9310
           volumeMounts:
-            - mountPath: /data/projects/fate/proxy/nginx/conf/route_table.yaml
+            - mountPath: /data/projects/fate/proxy/nginx/conf
               name: nginx-confs
-              subPath: route_table.yaml
-            - mountPath: /data/projects/fate/proxy/nginx/conf/nginx.conf
-              name: nginx-confs
-              subPath: nginx.conf
       {{- with .Values.modules.nginx.nodeSelector }}
       nodeSelector: 
 {{ toYaml . | indent 8 }}

--- a/helm-charts/FATE/templates/python-spark.yaml
+++ b/helm-charts/FATE/templates/python-spark.yaml
@@ -18,29 +18,6 @@ metadata:
     fateMoudle: python
 {{ include "fate.labels" . | indent 4 }}
 data:
-  rabbitmq_route_table.yaml: |
-    {{ .Values.partyId }}:
-      host: rabbitmq
-      port: 5672
-{{- range $key, $val := .Values.modules.rabbitmq.route_table }}
-    {{ $key }}: 
-{{ toYaml . | indent 6 }}
-{{- end }}
-  pulsar_route_table.yaml: |
-    {{- with .Values.modules.pulsar.exchange }}
-    default:
-      proxy: "{{ .ip }}:{{ .port }}"
-      domain: "fate.org"
-    {{- end }}
-    {{ .Values.partyId }}:
-      host: pulsar
-      port: 6650
-      sslPort: 6651
-      proxy: ""
-{{- range $key, $val := .Values.modules.pulsar.route_table }}
-    {{ $key }}: 
-{{ toYaml . | indent 6 }}
-{{- end }}
   spark-defaults.conf: |
     spark.master                      {{  .Values.modules.python.spark.master | default "local[4]"}}
     #spark.eventLog.enabled           true
@@ -111,14 +88,14 @@ data:
         user: {{ .Values.modules.python.rabbitmq.user }}
         password: {{ .Values.modules.python.rabbitmq.password }}
         # default conf/rabbitmq_route_table.yaml
-        route_table: {{ .Values.modules.python.rabbitmq.route_table }}
+        route_table: conf/rabbitmq_route_table/rabbitmq_route_table.yaml
       pulsar:
         host: {{ .Values.modules.python.pulsar.host }}
         port: {{ .Values.modules.python.pulsar.port }}
         mng_port: {{ .Values.modules.python.pulsar.mng_port }}
         topic_ttl: 3
         # default conf/pulsar_route_table.yaml
-        route_table: {{ .Values.modules.python.pulsar.route_table }}
+        route_table: conf/pulsar_route_table/pulsar_route_table.yaml
       nginx:
         host: {{ .Values.modules.python.nginx.host }}
         http_port: {{ .Values.modules.python.nginx.http_port }}
@@ -177,6 +154,47 @@ data:
     spring.datasource.druid.stat-view-servlet.enabled=false
     server.compression.enabled=true
     server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: pulsar-route-table
+  labels:
+    fateMoudle: python
+{{ include "fate.labels" . | indent 4 }}
+data:
+  pulsar_route_table.yaml: |
+    {{- with .Values.modules.pulsar.exchange }}
+    default:
+      proxy: "{{ .ip }}:{{ .port }}"
+      domain: "fate.org"
+    {{- end }}
+    {{ .Values.partyId }}:
+      host: pulsar
+      port: 6650
+      sslPort: 6651
+      proxy: ""
+{{- range $key, $val := .Values.modules.pulsar.route_table }}
+    {{ $key }}: 
+{{ toYaml . | indent 6 }}
+{{- end }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rabbitmq-route-table
+  labels:
+    fateMoudle: python
+{{ include "fate.labels" . | indent 4 }}
+data:
+  rabbitmq_route_table.yaml: |
+    {{ .Values.partyId }}:
+      host: rabbitmq
+      port: 5672
+{{- range $key, $val := .Values.modules.rabbitmq.route_table }}
+    {{ $key }}: 
+{{ toYaml . | indent 6 }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -288,12 +306,10 @@ spec:
             - mountPath: /data/projects/spark-2.4.1-bin-hadoop2.7/conf/spark-defaults.conf
               name: python-confs
               subPath: spark-defaults.conf
-            - mountPath: /data/projects/fate/conf/rabbitmq_route_table.yaml
-              name: python-confs
-              subPath: rabbitmq_route_table.yaml
-            - mountPath: /data/projects/fate/conf/pulsar_route_table.yaml
-              name: python-confs
-              subPath: pulsar_route_table.yaml
+            - mountPath: /data/projects/fate/conf/rabbitmq_route_table
+              name: rabbitmq-route-table
+            - mountPath: /data/projects/fate/conf/pulsar_route_table
+              name: pulsar-route-table
             - mountPath: /data/projects/fate/conf/
               name: shared-dir-conf
             - mountPath: /data/projects/fate/examples-shared-for-client
@@ -358,6 +374,12 @@ spec:
         - name: python-confs
           configMap:
             name: python-config
+        - name: rabbitmq-route-table
+          configMap:
+            name: rabbitmq-route-table
+        - name: pulsar-route-table
+          configMap:
+            name: pulsar-route-table
         - name: fateboard-confs
           configMap:
             name: fateboard-config


### PR DESCRIPTION
If you use kubefate update the router_table, it can update to pod.