### PR TITLE
Support pulsar working with load-balancer & exchange ATS

### DIFF
--- a/helm-charts/FATE/templates/pulsar.yaml
+++ b/helm-charts/FATE/templates/pulsar.yaml
@@ -1056,6 +1056,26 @@ spec:
     fateMoudle: pulsar
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
+{{ if .Values.modules.pulsar.publicLB.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: pulsar-public-tls
+  labels:
+    fateMoudle: pulsar
+{{ include "fate.labels" . | indent 4 }}
+spec:
+  ports:
+  - name: "tls-port"
+    port: 6651
+    targetPort: 6651
+    protocol: TCP
+  type: LoadBalancer
+  selector:
+    fateMoudle: pulsar
+{{ include "fate.matchLabels" . | indent 4 }}
+---
+{{ end }}
 {{ if and .Values.persistence.enabled (not .Values.modules.pulsar.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/helm-charts/FATE/templates/python-spark.yaml
+++ b/helm-charts/FATE/templates/python-spark.yaml
@@ -162,7 +162,7 @@ data:
     {{- with .Values.modules.pulsar.exchange }}
     default:
       proxy: "{{ .ip }}:{{ .port }}"
-      domain: "fate.org"
+      domain: "{{ .domain }}"
     {{- end }}
 {{- if .Values.modules.pulsar.route_table }}
 {{- range $key, $val := .Values.modules.pulsar.route_table }}

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -262,9 +262,12 @@ externalMysqlPassword: fate_dev1
   # type: ClusterIP
   # httpNodePort: 30094
   # httpsNodePort: 30099
+  # publicLB:
+    # enabled: false
   # exchange:
     # ip: 192.168.10.1
     # port: 30000
+    # domain: fate.org
   # route_table:
     # 10000:
       # host: 192.168.10.1

--- a/helm-charts/FATE/values-template.yaml
+++ b/helm-charts/FATE/values-template.yaml
@@ -454,10 +454,15 @@ modules:
     type: {{ .type }}
     httpNodePort: {{ .httpNodePort }}
     httpsNodePort: {{ .httpsNodePort }}
+    {{- with .publicLB}}
+    publicLB:
+      enabled: {{ .enabled | default false }}
+    {{- end }}
     {{- with .exchange }}
     exchange:
       ip: {{ .ip }}
       port: {{ .port }}
+      domain: {{ .domain | default "fate.org" }}
     {{- end }}
     route_table: 
       {{- range $key, $val := .route_table }}

--- a/helm-charts/FATE/values.yaml
+++ b/helm-charts/FATE/values.yaml
@@ -261,9 +261,12 @@ modules:
     type: ClusterIP
     httpNodePort: 30094
     httpsNodePort: 30099
+    publicLB:
+      enabled: false
     # exchange:
       # ip: 192.168.10.1
       # port: 30000
+      # domain: fate.org
     route_table: 
 #      10000:
 #        host: 192.168.10.1


### PR DESCRIPTION
1. make the exchange domain to be configurable, not limited to "fate.org".
2. add a "pulsar.publicLB.enabled" field to enable a new LB service to only expose the 6651 port.

Signed-off-by: Fangchi Wang <wfangchi@vmware.com>