### PR TITLE
Minor changes to accommodate for 1.6.1

### DIFF
--- a/docker-build/client/Examples/Pipeline/demo/pipeline-upload-spark.py
+++ b/docker-build/client/Examples/Pipeline/demo/pipeline-upload-spark.py
@@ -20,8 +20,8 @@ from pipeline.backend.config import Backend, WorkMode
 from pipeline.backend.pipeline import PipeLine
 
 # path to data
-# default fate installation path
-DATA_BASE = "/data/projects/fate"
+# default Examples folder path
+DATA_BASE = "/Examples"
 
 # site-package ver
 # import site

--- a/docker-build/client/Examples/Pipeline/demo/pipeline-upload.py
+++ b/docker-build/client/Examples/Pipeline/demo/pipeline-upload.py
@@ -20,8 +20,8 @@ from pipeline.backend.config import Backend, WorkMode
 from pipeline.backend.pipeline import PipeLine
 
 # path to data
-# default fate installation path
-DATA_BASE = "/data/projects/fate"
+# default Examples folder path
+DATA_BASE = "/Examples"
 
 # site-package ver
 # import site

--- a/docker-build/client/Examples/Pipeline/notebooks/usage_of_fate_client.ipynb
+++ b/docker-build/client/Examples/Pipeline/notebooks/usage_of_fate_client.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DATA_BASE = \"/data/projects/fate\""
+    "DATA_BASE = \"/Examples\""
    ]
   },
   {

--- a/k8s-deploy/kubefate.yaml
+++ b/k8s-deploy/kubefate.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: kubefate-admin
       containers:
-        - image: federatedai/kubefate:v1.4.1
+        - image: federatedai/kubefate:v1.4.2
           imagePullPolicy: IfNotPresent
           name: kubefate
           env:


### PR DESCRIPTION
1. Change dataset path in the client examples to the new path
2. Bump kubefate deployment image tag to 1.4.2

Signed-off-by: Fangchi Wang <wfangchi@vmware.com>