### PR TITLE
Fix the ingress api version of the kubefate service

### DIFF
--- a/k8s-deploy/kubefate.yaml
+++ b/k8s-deploy/kubefate.yaml
@@ -183,7 +183,7 @@ spec:
   selector:
     fate: kubefate
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: kubefate


### PR DESCRIPTION
The new ingress service definition in 1.7.0 needs the non-beta API version of Ingress.

Without this fix when applying the kubefate yaml the user gets the following error and the ingress is not deployed:

```bash
kubectl apply -f ./kubefate.yaml
deployment.apps/kubefate configured
deployment.apps/mariadb configured
service/mariadb unchanged
service/kubefate unchanged
error: error validating "./kubefate.yaml": error validating data: ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "service" in io.k8s.api.networking.v1beta1.IngressBackend; if you choose to ignore these errors, turn validation off with --validate=false
```


