### PR TITLE
Fixing wrong property names in example deploy configuration files

### DIFF
--- a/k8s-deploy/examples/party-10000/cluster-spark-local-pulsar.yaml
+++ b/k8s-deploy/examples/party-10000/cluster-spark-local-pulsar.yaml
@@ -55,8 +55,8 @@ servingPort: 30105
 
 nginx:
   type: NodePort
-  http_port: 30103
-  grpc_port: 30108 
+  httpNodePort: 30103
+  grpcNodePort: 30108 
   route_table: 
     9999: 
       fateflow: 

--- a/k8s-deploy/examples/party-10000/cluster-spark-pulsar.yaml
+++ b/k8s-deploy/examples/party-10000/cluster-spark-pulsar.yaml
@@ -57,8 +57,8 @@ servingPort: 30105
 
 nginx:
   type: NodePort
-  http_port: 30103
-  grpc_port: 30108 
+  httpNodePort: 30103
+  grpcNodePort: 30108 
   route_table: 
     9999: 
       fateflow: 

--- a/k8s-deploy/examples/party-10000/cluster-spark-rabbitmq.yaml
+++ b/k8s-deploy/examples/party-10000/cluster-spark-rabbitmq.yaml
@@ -57,8 +57,8 @@ servingPort: 30105
 
 nginx:
   type: NodePort
-  http_port: 30103
-  grpc_port: 30108 
+  httpNodePort: 30103
+  grpcNodePort: 30108 
   route_table: 
     9999: 
       fateflow: 


### PR DESCRIPTION
Changes:

1. Fixes wrong property names in example deploy configuration files

