### PR TITLE
Feat KubeFATE add liveness and readiness

### DIFF
--- a/docker-deploy/training_template/docker-compose-eggroll.yml
+++ b/docker-deploy/training_template/docker-compose-eggroll.yml
@@ -117,6 +117,12 @@ services:
     networks:
       fate-network:
         ipv4_address: 192.167.0.100
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-X POST", "http://192.167.0.100:9380/v1/version/get"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     command:
     - "/bin/bash"
     - "-c"

--- a/docker-deploy/training_template/docker-compose-spark-slim.yml
+++ b/docker-deploy/training_template/docker-compose-spark-slim.yml
@@ -71,6 +71,12 @@ services:
     networks:
       fate-network:
         ipv4_address: 192.167.0.100
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-X POST", "http://192.167.0.100:9380/v1/version/get"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     command:
     - "/bin/bash"
     - "-c"

--- a/docker-deploy/training_template/docker-compose-spark.yml
+++ b/docker-deploy/training_template/docker-compose-spark.yml
@@ -70,6 +70,12 @@ services:
     networks:
       fate-network:
         ipv4_address: 192.167.0.100
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-X POST", "http://192.167.0.100:9380/v1/version/get"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     command:
     - "/bin/bash"
     - "-c"

--- a/helm-charts/FATE/templates/backends/eggroll/clustermanager/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/clustermanager/deployment.yaml
@@ -53,6 +53,27 @@ spec:
             java -Dlog4j.configurationFile=$${EGGROLL_HOME}/conf/log4j2.properties -cp $${EGGROLL_HOME}/lib/*: com.webank.eggroll.core.Bootstrap --bootstraps com.webank.eggroll.core.resourcemanager.ClusterManagerBootstrap -c $${EGGROLL_HOME}/conf/eggroll.properties -p 4670 -s 'EGGROLL_DEAMON'
           ports:
             - containerPort: 4670
+          livenessProbe:
+            tcpSocket:
+              port: 4670
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 4670
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            tcpSocket:
+              port: 4670
+            failureThreshold: 12
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /data/projects/fate/eggroll/conf/eggroll.properties
               name: eggroll-confs

--- a/helm-charts/FATE/templates/backends/eggroll/nodemanager/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/nodemanager/deployment.yaml
@@ -67,6 +67,27 @@ spec:
             /tini -- java -Dlog4j.configurationFile=$${EGGROLL_HOME}/conf/log4j2.properties -cp $${EGGROLL_HOME}/lib/*: com.webank.eggroll.core.Bootstrap --bootstraps com.webank.eggroll.core.resourcemanager.NodeManagerBootstrap -c $${EGGROLL_HOME}/conf/eggroll.properties -p 4671 -s 'EGGROLL_DEAMON'
           ports:
             - containerPort: 4671
+          livenessProbe:
+            tcpSocket:
+              port: 4671
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 4671
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            tcpSocket:
+              port: 4671
+            failureThreshold: 12
+            periodSeconds: 10
           volumeMounts:
             - name: eggroll-log
               mountPath: /data/projects/fate/eggroll/logs/

--- a/helm-charts/FATE/templates/backends/eggroll/rollsite/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/rollsite/deployment.yaml
@@ -57,6 +57,27 @@ spec:
             java -Dlog4j.configurationFile=$${EGGROLL_HOME}/conf/log4j2.properties -cp $${EGGROLL_HOME}/lib/*:$${EGGROLL_HOME}/conf/ com.webank.eggroll.rollsite.EggSiteBootstrap -c $${EGGROLL_HOME}/conf/eggroll.properties
           ports:
             - containerPort: 9370
+          livenessProbe:
+            tcpSocket:
+              port: 9370
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 9370
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            tcpSocket:
+              port: 9370
+            failureThreshold: 12
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /data/projects/fate/eggroll/conf/route_table/
               name: rollsite-confs

--- a/helm-charts/FATE/templates/backends/spark/hdfs/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/deployment.yaml
@@ -54,6 +54,36 @@ spec:
             - containerPort: 9000
             - containerPort: 9870
             - containerPort: 50070
+          livenessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - curl -f localhost:50070
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - curl -f localhost:50070
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - curl -f localhost:50070
+            failureThreshold: 12
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /etc/hadoop/core-site.xml
               subPath: core-site.xml
@@ -124,7 +154,37 @@ spec:
           ports:
             - containerPort: 9000
             - containerPort: 9870
-            - containerPort: 50070
+            - containerPort: 50075
+          livenessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - curl -f localhost:50075
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - curl -f localhost:50075
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - curl -f localhost:50075
+            failureThreshold: 12
+            periodSeconds: 10
           volumeMounts:
           - name: dfs
             mountPath: /hadoop/dfs/data

--- a/helm-charts/FATE/templates/backends/spark/hdfs/service.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/service.yaml
@@ -27,9 +27,9 @@ spec:
       port: 9870
       targetPort: 9870
       protocol: TCP
-    - name: "tcp-50070"
-      port: 50070
-      targetPort: 50070
+    - name: "tcp-50075"
+      port: 50075
+      targetPort: 50075
       protocol: TCP
   type: {{ .Values.modules.hdfs.datanode.type }}
   selector:

--- a/helm-charts/FATE/templates/backends/spark/nginx/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/nginx/deployment.yaml
@@ -43,8 +43,43 @@ spec:
               echo "change path of route_table.yaml success!"
               openresty -g 'daemon off;'
           ports:
-            - containerPort: 9300
-            - containerPort: 9310
+            - name: http-port
+              containerPort: 9300
+            - name: grpc-port
+              containerPort: 9310
+          livenessProbe:
+            httpGet:
+              path: /test
+              port: 9302
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: livenessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /test
+              port: 9302
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: readinessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /test
+              port: 9302
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: readinessProbe
+            failureThreshold: 12
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /data/projects/fate/proxy/nginx/conf/nginx.conf
               name: nginx-confs

--- a/helm-charts/FATE/templates/backends/spark/pulsar/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/pulsar/deployment.yaml
@@ -45,6 +45,39 @@ spec:
             - containerPort: 6651
             - containerPort: 8080
             - containerPort: 8081
+          livenessProbe:
+            tcpSocket:
+              {{- if .Values.modules.pulsar.exchange }}
+              port: 8081
+              {{- else }}
+              port: 8080
+              {{- end }}
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              {{- if .Values.modules.pulsar.exchange }}
+              port: 8081
+              {{- else }}
+              port: 8080
+              {{- end }}
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            tcpSocket:
+              {{- if .Values.modules.pulsar.exchange }}
+              port: 8081
+              {{- else }}
+              port: 8080
+              {{- end }}
+            failureThreshold: 12
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /pulsar/conf/standalone.conf
               name: pulsar-confs

--- a/helm-charts/FATE/templates/backends/spark/rabbitmq/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/rabbitmq/deployment.yaml
@@ -49,6 +49,39 @@ spec:
           ports:
             - containerPort: 5672
             - containerPort: 15672
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 15672
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: livenessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 15672
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: readinessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 15672
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: startupProbe
+            failureThreshold: 12
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /etc/rabbitmq/enabled_plugins
               name: rabbitmq-confs

--- a/helm-charts/FATE/templates/backends/spark/spark/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/spark/deployment.yaml
@@ -46,6 +46,39 @@ spec:
             - containerPort: 8080
             - containerPort: 7077
             - containerPort: 6066
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: livenessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: readinessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 8080
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: startupProbe
+            failureThreshold: 12
+            periodSeconds: 10
       {{- with .Values.modules.spark.master.nodeSelector }}
       nodeSelector: 
 {{ toYaml . | indent 8 }}
@@ -102,6 +135,39 @@ spec:
               name: spark-worker-confs
           ports:
             - containerPort: 8081
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8081
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: livenessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8081
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: readinessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 8081
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: startupProbe
+            failureThreshold: 12
+            periodSeconds: 10
       {{- with .Values.modules.spark.worker.nodeSelector }}
       nodeSelector: 
 {{ toYaml . | indent 8 }}

--- a/helm-charts/FATE/templates/core/client/deployment.yaml
+++ b/helm-charts/FATE/templates/core/client/deployment.yaml
@@ -46,6 +46,39 @@ spec:
               value: "{{.Values.modules.serving.ip}}:{{.Values.modules.serving.port}}"
           ports:
             - containerPort: 20000
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 20000
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: livenessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 20000
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: readinessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 20000
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: startupProbe
+            failureThreshold: 12
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /data/projects/fate/persistence/
               name: persistence

--- a/helm-charts/FATE/templates/core/mysql/deployment.yaml
+++ b/helm-charts/FATE/templates/core/mysql/deployment.yaml
@@ -52,6 +52,33 @@ spec:
               value: root
           ports:
             - containerPort: 3306
+          livenessProbe:
+            exec:
+              command:
+              - mysqladmin
+              - ping
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+              - mysqladmin
+              - ping
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            exec:
+              command:
+              - mysqladmin
+              - ping
+            failureThreshold: 12
+            periodSeconds: 10
           volumeMounts:
             - name: mysql-confs
               mountPath: /docker-entrypoint-initdb.d/

--- a/helm-charts/FATE/templates/core/python-spark.yaml
+++ b/helm-charts/FATE/templates/core/python-spark.yaml
@@ -109,8 +109,10 @@ spec:
             value: "104868093952"
           {{- end }}
           ports:
-            - containerPort: 9360
-            - containerPort: 9380
+            - name: grpc-port
+              containerPort: 9360
+            - name: http-port
+              containerPort: 9380
           command:
             - /bin/bash
             - -c
@@ -133,6 +135,27 @@ spec:
                 ln -sf /dev/stdout /data/projects/fate/fateflow/logs/fate_flow/INFO.log
                 
                 sleep 5 && python fateflow/python/fate_flow/fate_flow_server.py
+          livenessProbe:
+            tcpSocket:
+              port: 9380
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 9380
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            tcpSocket:
+              port: 9380
+            failureThreshold: 12
+            periodSeconds: 10
           volumeMounts:
             {{- if eq .Values.modules.python.backend "eggroll" }}
             - mountPath: /data/projects/fate/eggroll/conf/eggroll.properties
@@ -168,6 +191,39 @@ spec:
           name: fateboard
           ports:
             - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: livenessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: readinessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 8080
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: startupProbe
+            failureThreshold: 12
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /data/projects/fate/fateboard/conf/application.properties
               name: fateboard-confs

--- a/helm-charts/Images_list.md
+++ b/helm-charts/Images_list.md
@@ -12,12 +12,12 @@ FATE:
 - fluent/fluentd:v1.12
 - federatedai/spark-master:${version-tag}
 - federatedai/spark-worker:${version-tag}
-- hadoop-datanode:2.0.0-hadoop2.7.4-java8
-- hadoop-namenode:2.0.0-hadoop2.7.4-java8
+- federatedai/hadoop-datanode:2.0.0-hadoop2.7.4-java8
+- federatedai/hadoop-namenode:2.0.0-hadoop2.7.4-java8
 - nginx:1.17
 - federatedai/nginx:${version-tag}
-- rabbitmq:3.8.3-management
-- pulsar:2.7.0
+- federatedai/rabbitmq:3.8.3-management
+- federatedai/pulsar:2.7.0
 
 
 

--- a/k8s-deploy/kubefate.yaml
+++ b/k8s-deploy/kubefate.yaml
@@ -72,6 +72,39 @@ spec:
             requests:
               memory: 512Mi
               cpu: "0.5"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: livenessProbe
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: readinessProbe
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 8080
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: startupProbe
+            failureThreshold: 30
+            periodSeconds: 10
       restartPolicy: Always
 ---
 apiVersion: apps/v1
@@ -125,6 +158,26 @@ spec:
           volumeMounts:
             - name: mariadb-data
               mountPath: /var/lib/mysql
+          livenessProbe:
+            exec:
+              command:
+              - mysqladmin
+              - ping
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+              - mysqladmin
+              - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
       restartPolicy: Always
       volumes:
         - name: mariadb-data


### PR DESCRIPTION
# Desc
Complete this task #552

Changes:

1. Add liveness readiness and startup for kubefate service, also includes mariadb service.
2. Add liveness readiness and startup for FATE chart
3. Add `healthcheck` for docker-compose's python 

# Test
1. After modification, kubefate can run successfully
```bash
$ kubectl get pod -n kube-fate
NAME                        READY   STATUS    RESTARTS         AGE
mariadb-66bb7d68b7-vpvdm    1/1     Running   5 (3h45m ago)    10d
kubefate-6fc58f87df-hjvbt   1/1     Running   93 (3h45m ago)   10d
$ kubefate version
* kubefate commandLine version=v1.4.3
* kubefate service version=v1.4.4
$ kubectl  -n kube-fate logs kubefate-6fc58f87df-hjvbt
2022-03-28T07:04:35Z INF Request ip=10.42.0.1 latency=0.052 method=GET path=/ status=200 user_agent=kube-probe/1.23
2022-03-28T07:04:43Z INF Request ip=10.42.0.1 latency=0.049 method=GET path=/ status=200 user_agent=kube-probe/1.23
2022-03-28T07:04:45Z INF Request ip=10.42.0.1 latency=0.157 method=GET path=/ status=200 user_agent=kube-probe/1.23
```
2. Deploying FATE also got the expected results
![image](https://user-images.githubusercontent.com/21351918/160345993-70299a22-aee6-4878-a014-6fd41b58b58a.png)

4. The healthcheck of FATE deployed by docker-compose has taken effect
<img width="861" alt="image" src="https://user-images.githubusercontent.com/21351918/160345110-94c23d8e-8314-42c6-a24b-b8a8c9ad9e59.png">

