### PR TITLE
fix ingress definition issue in the tutorials

### DIFF
--- a/docs/tutorials/Build_Two_Parties_FATE_Cluster_in_One_Linux_Machine_with_MiniKube.md
+++ b/docs/tutorials/Build_Two_Parties_FATE_Cluster_in_One_Linux_Machine_with_MiniKube.md
@@ -242,6 +242,7 @@ istio:
   enabled: false
 podSecurityPolicy:
   enabled: false
+ingressClassName: nginx
 modules:
   - rollsite
   - clustermanager
@@ -255,13 +256,9 @@ backend: eggroll
 
 ingress:
   fateboard:
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
     hosts:
     - name: party9999.fateboard.example.com
-  client:
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
+  client:  
     hosts:
     - name: party9999.notebook.example.com
 
@@ -299,6 +296,7 @@ istio:
   enabled: false
 podSecurityPolicy:
   enabled: false
+ingressClassName: nginx
 modules:
   - rollsite
   - clustermanager
@@ -312,13 +310,9 @@ backend: eggroll
 
 ingress:
   fateboard:
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
     hosts:
     - name: party10000.fateboard.example.com
-  client:
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
+  client:  
     hosts:
     - name: party10000.notebook.example.com
 

--- a/docs/tutorials/Build_Two_Parties_FATE_Cluster_in_One_Linux_Machine_with_MiniKube_zh.md
+++ b/docs/tutorials/Build_Two_Parties_FATE_Cluster_in_One_Linux_Machine_with_MiniKube_zh.md
@@ -221,6 +221,7 @@ istio:
   enabled: false
 podSecurityPolicy:
   enabled: false
+ingressClassName: nginx
 modules:
   - rollsite
   - clustermanager
@@ -234,13 +235,9 @@ backend: eggroll
 
 ingress:
   fateboard:
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
     hosts:
     - name: party9999.fateboard.example.com
-  client:
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
+  client:  
     hosts:
     - name: party9999.notebook.example.com
 
@@ -279,6 +276,7 @@ istio:
   enabled: false
 podSecurityPolicy:
   enabled: false
+ingressClassName: nginx
 modules:
   - rollsite
   - clustermanager
@@ -292,13 +290,9 @@ backend: eggroll
 
 ingress:
   fateboard:
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
     hosts:
     - name: party10000.fateboard.example.com
-  client:
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
+  client:  
     hosts:
     - name: party10000.notebook.example.com
 


### PR DESCRIPTION
The ingress definition in the tutorials are using the old annotation way, now we change it to the right way.

