### PR TITLE
add configmap for notebook, turn on allow all origins

### DIFF
--- a/helm-charts/FATE/templates/core/client/configmap.yaml
+++ b/helm-charts/FATE/templates/core/client/configmap.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.modules.client.include }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: client
+  labels:
+    fateMoudle: client
+{{ include "fate.labels" . | indent 4 }}
+data:
+  jupyter_notebook_config.py: |
+    c.NotebookApp.allow_origin = '*'
+{{ end }}

--- a/helm-charts/FATE/templates/core/client/deployment.yaml
+++ b/helm-charts/FATE/templates/core/client/deployment.yaml
@@ -83,6 +83,9 @@ spec:
             - mountPath: /data/projects/fate/persistence/
               name: persistence
               subPath: {{ .Values.modules.client.subPath }}
+            - mountPath: /root/.jupyter/jupyter_notebook_config.py
+              name: client-configmap
+              subPath: jupyter_notebook_config.py
       {{- with .Values.modules.client.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -110,4 +113,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.modules.client.existingClaim | default  "client-data" }}
         {{- end }}
+        - name: client-configmap
+          configMap:
+            name: client        
 {{ end }}


### PR DESCRIPTION
add configmap for notebook, turn on allow all origins

Sometimes we need nginx as proxy on k8s, jupyter notebook need turn on allow all origins, if not jupyter notebook can not work correctly