### PR TITLE
fix issue, it will cause fateflow log error, and scheduler do not work correctly.

### DIFF
--- a/helm-charts/FATE/templates/core/python-spark.yaml
+++ b/helm-charts/FATE/templates/core/python-spark.yaml
@@ -129,11 +129,6 @@ spec:
                 cp /data/projects/spark-2.4.1-bin-hadoop2.7/conf/spark-defaults-template.conf /data/projects/spark-2.4.1-bin-hadoop2.7/conf/spark-defaults.conf
                 sed -i "s/fateflow/${POD_IP}/g" /data/projects/spark-2.4.1-bin-hadoop2.7/conf/spark-defaults.conf
                 
-                # logs
-                mkdir -p /data/projects/fate/fateflow/logs/fate_flow/
-                touch /data/projects/fate/fateflow/logs/fate_flow/INFO.log
-                ln -sf /dev/stdout /data/projects/fate/fateflow/logs/fate_flow/INFO.log
-                
                 sleep 5 && python fateflow/python/fate_flow/fate_flow_server.py
           livenessProbe:
             tcpSocket:


### PR DESCRIPTION
Signed-off-by: stone-wlg <stone_wlg@163.com>

fix issue, it will cause fateflow log error, and scheduler do not work correctly.

> 

--- Logging error ---
Traceback (most recent call last):
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/logging/handlers.py", line 73, in emit
    logging.FileHandler.emit(self, record)
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/logging/__init__.py", line 1071, in emit
    self.stream = self._open()
  File "/data/projects/fate/fate/python/fate_arch/common/log.py", line 211, in _open
    rtv = TimedRotatingFileHandler._open(self)
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/logging/__init__.py", line 1061, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding)
OSError: [Errno 29] Illegal seek
Call stack:
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/threading.py", line 884, in _bootstrap
    self._bootstrap_inner()
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/data/projects/fate/fateflow/python/fate_flow/utils/cron.py", line 77, in run
    do()
  File "/data/projects/fate/fateflow/python/fate_flow/utils/cron.py", line 48, in do
    self.run_do()
  File "/data/projects/fate/fateflow/python/fate_flow/scheduler/dag_scheduler.py", line 226, in run_do
    schedule_logger().info("schedule running jobs finished")
Message: 'schedule running jobs finished'



