### PR TITLE
Resolve the log flood issue of kubefate pod

### DIFF
--- a/k8s-deploy/kubefate.yaml
+++ b/k8s-deploy/kubefate.yaml
@@ -72,39 +72,6 @@ spec:
             requests:
               memory: 512Mi
               cpu: "0.5"
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 8080
-              httpHeaders:
-                - name: X-Custom-Header
-                  value: livenessProbe
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            successThreshold: 1
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 8080
-              httpHeaders:
-                - name: X-Custom-Header
-                  value: readinessProbe
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 1
-            successThreshold: 1
-            failureThreshold: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 8080
-              httpHeaders:
-                - name: X-Custom-Header
-                  value: startupProbe
-            failureThreshold: 30
-            periodSeconds: 10
       restartPolicy: Always
 ---
 apiVersion: apps/v1
@@ -164,7 +131,7 @@ spec:
               - mysqladmin
               - ping
             initialDelaySeconds: 30
-            periodSeconds: 10
+            periodSeconds: 30
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
@@ -173,8 +140,8 @@ spec:
               command:
               - mysqladmin
               - ping
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: 30
+            periodSeconds: 30
             timeoutSeconds: 1
             successThreshold: 1
             failureThreshold: 3

--- a/k8s-deploy/kubefate.yaml
+++ b/k8s-deploy/kubefate.yaml
@@ -72,6 +72,27 @@ spec:
             requests:
               memory: 512Mi
               cpu: "0.5"
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            tcpSocket:
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 10
       restartPolicy: Always
 ---
 apiVersion: apps/v1

--- a/k8s-deploy/pkg/api/service.go
+++ b/k8s-deploy/pkg/api/service.go
@@ -17,6 +17,7 @@ package api
 
 import (
 	"fmt"
+	"github.com/rs/zerolog"
 	"os"
 	"time"
 
@@ -132,6 +133,7 @@ func Run() error {
 		logger.SetLogger(
 			logger.WithUTC(true),
 			logger.WithLogger(logging.GetGinLogger),
+			logger.WithDefaultLevel(zerolog.DebugLevel),
 		),
 	)
 


### PR DESCRIPTION
Fixes  ISSUE #611 

## Changes:

1. Remove the probe of kubefate service, this is not neessary, because that is a service supporting an CLI application. This kind of service shouldn't need probe.

2. Reduce the frequency for the mariaDB service's probe.

3. Change the log level to debug for the gin framework.

## Test
Before fix there is log flood like #611 showing.
After fix verified that the gin response log is changed to debug:

> 2022-05-11T13:41:06Z DBG Request ip=172.17.0.1 latency=0.168826 method=GET path=/ status=200 user_agent=kube-probe/1.19

