### PR TITLE
Make sure in docker compose mode, we can upload a dataset > 100M size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,9 @@
 #
 # These files are text and should be normalized (Convert crlf => lf)
 *.PNG           binary
+*.png           binary
+*.jpg           binary
+*.pdf           binary
 
 #
 # Exclude files from exporting

--- a/docker-deploy/generate_config.sh
+++ b/docker-deploy/generate_config.sh
@@ -88,7 +88,7 @@ GenerateConfig() {
 			cp -r training_template/backends/spark/rabbitmq confs-$party_id/confs/
 			
 			cp training_template/docker-compose-spark.yml confs-$party_id/docker-compose.yml
-			sed -i '163,179d' confs-$party_id/docker-compose.yml
+			sed -i '186,203d' confs-$party_id/docker-compose.yml
 		fi
 
 		if [ "$backend" == "spark_pulsar" ]; then
@@ -98,7 +98,7 @@ GenerateConfig() {
 			cp -r training_template/backends/spark/pulsar confs-$party_id/confs/
 			
 			cp training_template/docker-compose-spark.yml confs-$party_id/docker-compose.yml
-			sed -i '145,161d' confs-$party_id/docker-compose.yml
+			sed -i '168,185d' confs-$party_id/docker-compose.yml
 		fi
 
 		if [ "$backend" == "spark_local_pulsar" ]; then

--- a/docker-deploy/training_template/docker-compose-eggroll.yml
+++ b/docker-deploy/training_template/docker-compose-eggroll.yml
@@ -1,5 +1,5 @@
-# Copyright 2019-2020 VMware, Inc.
-# 
+# Copyright 2019-2022 VMware, Inc.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # you may obtain a copy of the License at
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version: '3'
+version: '3.7'
 networks:
   fate-network:
     ipam:

--- a/docker-deploy/training_template/docker-compose-exchange.yml
+++ b/docker-deploy/training_template/docker-compose-exchange.yml
@@ -1,4 +1,16 @@
-version: '3'
+# Copyright 2019-2022 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# you may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+version: '3.7'
 
 services:
   exchange:

--- a/docker-deploy/training_template/docker-compose-spark-slim.yml
+++ b/docker-deploy/training_template/docker-compose-spark-slim.yml
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 VMware, Inc.
+# Copyright 2019-2022 VMware, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version: "3"
+version: "3.7"
 
 networks:
   fate-network:

--- a/docker-deploy/training_template/docker-compose-spark.yml
+++ b/docker-deploy/training_template/docker-compose-spark.yml
@@ -105,11 +105,35 @@ services:
     networks:
       - fate-network
 
-  datanode:
+  datanode-0:
     image: federatedai/hadoop-datanode:2.0.0-hadoop2.7.4-java8
     restart: always
     volumes:
-      - ./shared_dir/data/datanode:/hadoop/dfs/data
+      - ./shared_dir/data/datanode-0:/hadoop/dfs/data
+    environment:
+      SERVICE_PRECONDITION: "namenode:9000"
+    env_file:
+      - ./confs/hadoop/hadoop.env
+    networks:
+      - fate-network
+
+  datanode-1:
+    image: federatedai/hadoop-datanode:2.0.0-hadoop2.7.4-java8
+    restart: always
+    volumes:
+      - ./shared_dir/data/datanode-1:/hadoop/dfs/data
+    environment:
+      SERVICE_PRECONDITION: "namenode:9000"
+    env_file:
+      - ./confs/hadoop/hadoop.env
+    networks:
+      - fate-network
+
+  datanode-2:
+    image: federatedai/hadoop-datanode:2.0.0-hadoop2.7.4-java8
+    restart: always
+    volumes:
+      - ./shared_dir/data/datanode-2:/hadoop/dfs/data
     environment:
       SERVICE_PRECONDITION: "namenode:9000"
     env_file:

--- a/docker-deploy/training_template/docker-compose-spark.yml
+++ b/docker-deploy/training_template/docker-compose-spark.yml
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 VMware, Inc.
+# Copyright 2019-2022 VMware, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version: "3"
+version: "3.7"
 
 networks:
   fate-network:


### PR DESCRIPTION
Fixes #600

## Description
- We are reported that in the docker compose mode, when the dataset is > 100M then we cannot upload it, this is because that there is only one datanode of HDFS.
- In this change we make the datenode replicas to be 3. **Please notice that this is just an workaround as code, because even we set it to 3, it doesn't mean that the HDFS is a distributed system**.
- We take the docker compose mode as a POC-level stuff. This change is just aim to let people to upload a bigger file in their POCs.
- This change also fix some docker-compose yaml file version issue, if keep it as 3, then the health check aattributes cannot be recognized.

## Test
1. The deployment success, and run the 2 test cases successfully:
```
party 9999 cluster min_test_task test is success!
party 9999 cluster toy_example test is success!
```
2. truncate the file to 120M, and upload it successfully:
![Screen Shot 2022-05-18 at 11 45 50 AM](https://user-images.githubusercontent.com/15973672/168954503-b278ccc2-1906-4e8e-87bb-080eafb7dc95.png)
![Screen Shot 2022-05-18 at 11 28 54 AM](https://user-images.githubusercontent.com/15973672/168953788-7efe6184-6ac9-4993-a2a4-5b35729d43fb.png)

3. Verified that 3 datanode containers are up, and the namenode has them registered successfully:
![Screen Shot 2022-05-18 at 10 52 10 AM](https://user-images.githubusercontent.com/15973672/168954077-5fb2000d-6c08-4452-ad65-0f780f52f444.png)
```
root@90c655b132f4:/# hdfs dfsadmin -report | grep Name
Name: 192.167.0.5:50010 (confs-9999_datanode-0_1.confs-9999_fate-network)
Name: 192.167.0.3:50010 (confs-9999_datanode-2_1.confs-9999_fate-network)
Name: 192.167.0.4:50010 (confs-9999_datanode-1_1.confs-9999_fate-network)
```

4. Verified that the problem in issue #601 doesn't exist.
