### PR TITLE
fix: Remove variable 'ingressHost' that is no longer in use

### DIFF
--- a/docs/configurations/FATE_Exchange_cluster_configuration.md
+++ b/docs/configurations/FATE_Exchange_cluster_configuration.md
@@ -29,7 +29,6 @@ It is used to declare the `servingProxy` module in the FATE cluster to be deploy
 | Name         | subitem   | Type      | Description                                                  |
 | ------------ | --------- | --------- | ------------------------------------------------------------ |
 | nodePort     |           | scalars   | The port used by `proxy` module's kubernetes service, default range: 30000-32767. |
-| ingerssHost  |           | scalars   | The entrance of FATE-Service api.                            |
 | partyList    |           | sequences | If this FATE cluster is exchange cluster, partyList is all party's sequences of all parties proxy address. If this FATE cluster is one of participants, delete this configuration item. |
 | partyList    | partyId   | scalars   | Participant FATE cluster party ID.                           |
 | partyList    | partyIp   | scalars   | Participant FATE cluster IP.                                 |

--- a/helm-charts/FATE-Serving/values-template.yaml
+++ b/helm-charts/FATE-Serving/values-template.yaml
@@ -70,7 +70,6 @@ servingProxy:
   type: {{ .type }}
   nodePort: {{ .nodePort }}
   loadBalancerIP: {{ .loadBalancerIP }}
-  ingerssHost: {{ .ingressHost | default (printf "%s.serving-admin.example.com" $partyId) }}
 
   {{- with .partyList }}
   partyList:


### PR DESCRIPTION
Signed-off-by: magic-hya <huangya@asiainfo.com>

Fixes  ISSUE Remove variable 'ingressHost' that is no longer in use

There is no place using this variable in the helm chart.

