### PR TITLE
Remove "condition: any" in the pulsar's docker compose file

### DIFF
--- a/docker-deploy/training_template/docker-compose-spark-slim.yml
+++ b/docker-deploy/training_template/docker-compose-spark-slim.yml
@@ -122,9 +122,6 @@ services:
       - "6650:6650"
       - "6651:6651"
       - "8001:8080"
-    deploy:
-      restart_policy:
-        condition: any
     volumes:
       - ./confs/pulsar/standalone.conf:/pulsar/conf/standalone.conf
       - ./shared_dir/data/pulsar:/pulsar/data

--- a/docker-deploy/training_template/docker-compose-spark.yml
+++ b/docker-deploy/training_template/docker-compose-spark.yml
@@ -190,9 +190,6 @@ services:
       - "6650:6650"
       - "6651:6651"
       - "8001:8080"
-    deploy:
-      restart_policy:
-        condition: any
     volumes:
       - ./confs/pulsar/standalone.conf:/pulsar/conf/standalone.conf
       - ./shared_dir/data/pulsar:/pulsar/data


### PR DESCRIPTION
##Description
Fixes  #616 

This is due to a docker compose known issue: 
https://github.com/docker/compose/issues/8756

I make this change based on 2 reasons:
1. We have already set `restart: always`
2. Due to the doc (https://docs.docker.com/compose/compose-file/compose-file-v3/), the default value is `any`, if the known issue can be fixed in the future.

##Test
### Before fix
![Screen Shot 2022-05-24 at 11 05 00 PM](https://user-images.githubusercontent.com/15973672/170078807-96555173-d2fa-4453-b921-863017582d1c.png)

### After fix
![Screen Shot 2022-05-24 at 11 31 55 PM](https://user-images.githubusercontent.com/15973672/170078891-218610ab-a1a5-4e17-82cf-11c32b64083d.png)




