### PR TITLE
KubeFATE support FATE-Serving v2.1.5 (#606) (#624)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,8 @@
 #
 # These files are text and should be normalized (Convert crlf => lf)
 *.PNG           binary
+*.png           binary
+*.jpg           binary
 
 #
 # Exclude files from exporting

--- a/build/ci/docker-deploy/docker_deploy.sh
+++ b/build/ci/docker-deploy/docker_deploy.sh
@@ -2,7 +2,7 @@
 set -x
 dir=$(dirname $0)
 
-CONTAINER_NUM=13
+CONTAINER_NUM=12
 
 echo "# config prepare"
 target_dir=/data/projects/fate

--- a/docker-deploy/.env
+++ b/docker-deploy/.env
@@ -1,6 +1,6 @@
 RegistryURI=
 TAG=1.8.0-release
-SERVING_TAG=2.0.4-release
+SERVING_TAG=2.1.5-release
 
 # PREFIX: namespace on the registry's server.
 # RegistryURI: address of the local registry

--- a/docker-deploy/README_zh.md
+++ b/docker-deploy/README_zh.md
@@ -1,20 +1,20 @@
-## 使用Docker Compose 部署 FATE
+# 使用Docker Compose 部署 FATE
 
-### 前言
+## 前言
 
-[FATE](https://www.fedai.org/ )是一个联邦学习框架，能有效帮助多个机构在满足用户隐私保护、数据安全和政府法规的要求下，进行数据使用和建模。项目地址：（https://github.com/FederatedAI/FATE/） 本文档介绍使用Docker Compose部署FATE集群的方法。
+[FATE](https://www.fedai.org/ )是一个联邦学习框架，能有效帮助多个机构在满足用户隐私保护、数据安全和政府法规的要求下，进行数据使用和建模。项目地址：（<https://github.com/FederatedAI/FATE/>） 本文档介绍使用Docker Compose部署FATE集群的方法。
 
-### Docker Compose 简介
+## Docker Compose 简介
 
 Compose是用于定义和运行多容器Docker应用程序的工具。通过Compose，您可以使用YAML文件来配置应用程序的服务。然后，使用一个命令，就可以从配置中创建并启动所有服务。要了解有关Compose的所有功能的更多信息，请参阅[相关文档](https://docs.docker.com/compose/#features)。
 
 使用Docker compose 可以方便的部署FATE，下面是使用步骤。
 
-### 目标
+## 目标
 
 两个可以互通的FATE实例，每个实例均包括FATE所有组件。
 
-### 准备工作
+## 准备工作
 
 1. 两个主机（物理机或者虚拟机，都是Centos7系统）；
 2. 所有主机安装Docker 版本 : 18+；
@@ -44,13 +44,14 @@ RegistryURI=hub.c.163.com
 如果运行机没有FATE组件的镜像，可以通过以下命令从Docker Hub获取镜像。FATE镜像的版本`<version>`可在[release页面](https://github.com/FederatedAI/FATE/releases)上查看，其中serving镜像的版本信息在[这个页面](https://github.com/FederatedAI/FATE-Serving/releases)：
 
 ```bash
-$ docker pull federatedai/eggroll:<version>-release
-$ docker pull federatedai/fateboard:<version>-release
-$ docker pull federatedai/python:<version>-release
-$ docker pull federatedai/serving-server:<version>-release
-$ docker pull federatedai/serving-proxy:<version>-release
-$ docker pull redis:5
-$ docker pull mysql:8
+docker pull federatedai/eggroll:<version>-release
+docker pull federatedai/fateboard:<version>-release
+docker pull federatedai/python:<version>-release
+docker pull federatedai/serving-server:<version>-release
+docker pull federatedai/serving-proxy:<version>-release
+docker pull federatedai/serving-admin:<version>-release
+docker pull bitnami/zookeeper:3.7.0 
+docker pull mysql:8.0.28
 ```
 
 检查所有镜像是否下载成功。
@@ -64,8 +65,9 @@ federatedai/python                 <version>-release
 federatedai/client                 <version>-release
 federatedai/serving-server         <version>-release
 federatedai/serving-proxy          <version>-release
-redis                              5
-mysql                              8
+federatedai/serving-admin          <version>-release
+bitnami/zookeeper                  3.7.0 
+mysql                              8.0.28
 ```
 
 ### 离线部署（可选）
@@ -81,11 +83,11 @@ RegistryURI=192.168.10.1/federatedai
 ...
 ```
 
-### 用Docker Compose部署FATE
+## 用Docker Compose部署FATE
 
   ***如果在之前你已经部署过其他版本的FATE，请删除清理之后再部署新的版本，[删除部署](#删除部署).***
 
-#### 配置需要部署的实例数目
+### 配置需要部署的实例数目
 
 部署脚本提供了部署多个FATE实例的功能，下面的例子我们部署在两个机器上，每个机器运行一个FATE实例，这里两台机器的IP分别为*192.168.7.1*和*192.168.7.2*
 
@@ -93,23 +95,40 @@ RegistryURI=192.168.10.1/federatedai
 
 下面是修改好的文件，`party 10000`的集群将部署在*192.168.7.1*上，而`party 9999`的集群将部署在*192.168.7.2*上。为了减少所需拉取镜像的大小，KubeFATE在默认情况下，会使用不带神经网络的“python”容器，若需要跑神经网络的算法则需把“parties.conf”中的`enabled_nn`设置成`true`。
 
-```
-user=fate                                   # 运行FATE容器的用户
-dir=/data/projects/fate                     # docker-compose部署目录
-partylist=(10000 9999)                      # 组织id
-partyiplist=(192.168.7.1 192.168.7.2)       # id对应训练集群ip
-servingiplist=(192.168.7.1 192.168.7.2)     # id对应在线预测集群ip
-# computing_backend could be eggroll or spark.
-computing_backend=eggroll
+```bash
+user=fate
+dir=/data/projects/fate
+party_list=(10000 9999)
+party_ip_list=(192.168.7.1 192.168.7.2)
+serving_ip_list=(192.168.7.1 192.168.7.2)
+
+# backend could be eggroll, spark_rabbitmq and spark_pulsar spark_local_pulsar
+backend=eggroll
 
 # true if you need python-nn else false, the default value will be false
 enabled_nn=false
 
-fateboard_username=admin                    # 访问fateboard的用户名
-fateboard_password=admin                    # 访问fateboard的密码
+# default
+exchangeip=
+
+# modify if you are going to use an external db
+mysql_ip=mysql
+mysql_user=fate
+mysql_password=fate_dev
+mysql_db=fate_flow
+
+name_node=hdfs://namenode:9000
+
+# Define fateboard login information
+fateboard_username=admin
+fateboard_password=admin
+
+# Define serving admin login information
+serving_admin_username=admin
+serving_admin_password=admin
 ```
 
-FATE 1.5 支持使用Spark作为底层的分布式计算引擎，Spark集群默认会通过容器的方式部署。相关的简介可以参考这个[链接](../docs/FATE_On_Spark.md).
+FATE v1.5 开始支持使用Spark作为底层的分布式计算引擎，Spark集群默认会通过容器的方式部署。相关的简介可以参考这个[链接](../docs/FATE_On_Spark.md).
 
 **注意**: 默认情况下不会部署exchange组件。如需部署，用户可以把服务器IP填入上述配置文件的`exchangeip`中，该组件的默认监听端口为9371
 
@@ -137,55 +156,49 @@ total 0
 drwxr-xr-x. 2 fate docker 6 May 27 00:51 fate
 ```
 
-#### 执行部署脚本
+### 执行部署脚本
+
 以下修改可在任意机器执行。
 
 进入目录`kubeFATE\docker-deploy`，然后运行：
 
 ```bash
-$ ./generate_config.sh          # 生成部署文件
-$ ./docker_deploy.sh all        # 在各个party上部署FATE
+bash ./generate_config.sh          # 生成部署文件
+bash ./docker_deploy.sh all        # 在各个party上部署FATE
 ```
+
 脚本将会生成10000、9999两个组织(Party)的部署文件，然后打包成tar文件。接着把tar文件`confs-<party-id>.tar`、`serving-<party-id>.tar`分别复制到party对应的主机上并解包，解包后的文件默认在`/data/projects/fate`目录下。然后脚本将远程登录到这些主机并使用docker compose命令启动FATE实例。
 
 命令成功执行返回后，登录其中任意一个主机：
 
 ```bash
-$ ssh root@192.168.7.1
+ssh root@192.168.7.1
 ```
 
 使用以下命令验证实例状态，
 
 ```bash
-$ docker ps
+docker ps
 ````
+
 输出显示如下，若各个组件都是运行（up）状态，说明部署成功。
 
-```
-CONTAINER ID        IMAGE                                     COMMAND                  CREATED             STATUS              PORTS                                 NAMES
-69b8b36af395        federatedai/eggroll:<tag>          "bash -c 'java -Dlog…"   2 hours ago         Up 2 hours    
-      0.0.0.0:9371->9370/tcp                                                   confs-exchange_exchange_1
-71cd792ba088        federatedai/serving-proxy:<tag>    "/bin/sh -c 'java -D…"   2 hours ago         Up 2 hours    
-      0.0.0.0:8059->8059/tcp, 0.0.0.0:8869->8869/tcp, 8879/tcp                 serving-10000_serving-proxy_1
-2c79047918c6        federatedai/serving-server:<tag>   "/bin/sh -c 'java -c…"   2 hours ago         Up 2 hours    
-      0.0.0.0:8000->8000/tcp                                                   serving-10000_serving-server_1
-b1a5384a55dc        redis:5                            "docker-entrypoint.s…"   2 hours ago         Up 2 hours    
-      6379/tcp                                                                 serving-10000_redis_1
-321c4e29313b        federatedai/client:<tag>           "/bin/sh -c 'sleep 5…"   2 hours ago         Up 2 hours    
-      0.0.0.0:20000->20000/tcp                                                 confs-10000_client_1
-c1b3190126ab        federatedai/fateboard:<tag>        "/bin/sh -c 'java -D…"   2 hours ago         Up 2 hours    
-      0.0.0.0:8080->8080/tcp                                                   confs-10000_fateboard_1
-cc679996e79f        federatedai/python:<tag>           "/bin/sh -c 'sleep 5…"   2 hours ago         Up 2 hours    
-      0.0.0.0:8484->8484/tcp, 0.0.0.0:9360->9360/tcp, 0.0.0.0:9380->9380/tcp   confs-10000_python_1
-c79800300000        federatedai/eggroll:<tag>          "bash -c 'java -Dlog…"   2 hours ago         Up 2 hours    
-      4671/tcp                                                                 confs-10000_nodemanager_1
-ee2f1c3aad99        federatedai/eggroll:<tag>          "bash -c 'java -Dlog…"   2 hours ago         Up 2 hours    
-      4670/tcp                                                                 confs-10000_clustermanager_1
-a1f784882d20        federatedai/eggroll:<tag>          "bash -c 'java -Dlog…"   2 hours ago         Up 2 hours                  0.0.0.0:9370->9370/tcp                                                   confs-10000_rollsite_1
-2b4526e6d534        mysql:8                            "docker-entrypoint.s…"   2 hours ago         Up 2 hours                  3306/tcp, 33060/tcp                                                      confs-10000_mysql_1
+```bash
+CONTAINER ID   IMAGE                                      COMMAND                  CREATED         STATUS                   PORTS                                                                                                                                           NAMES
+5d2e84ba4c77   federatedai/serving-server:2.1.5-release   "/bin/sh -c 'java -c…"   5 minutes ago   Up 5 minutes             0.0.0.0:8000->8000/tcp, :::8000->8000/tcp                                                                                                       serving-9999_serving-server_1
+3dca43f3c9d5   federatedai/serving-admin:2.1.5-release    "/bin/sh -c 'java -c…"   5 minutes ago   Up 5 minutes             0.0.0.0:8350->8350/tcp, :::8350->8350/tcp                                                                                                       serving-9999_serving-admin_1
+fe924918509b   federatedai/serving-proxy:2.1.5-release    "/bin/sh -c 'java -D…"   5 minutes ago   Up 5 minutes             0.0.0.0:8059->8059/tcp, :::8059->8059/tcp, 0.0.0.0:8869->8869/tcp, :::8869->8869/tcp, 8879/tcp                                                  serving-9999_serving-proxy_1
+b62ed8ba42b7   bitnami/zookeeper:3.7.0                    "/opt/bitnami/script…"   5 minutes ago   Up 5 minutes             0.0.0.0:2181->2181/tcp, :::2181->2181/tcp, 8080/tcp, 0.0.0.0:49226->2888/tcp, :::49226->2888/tcp, 0.0.0.0:49225->3888/tcp, :::49225->3888/tcp   serving-9999_serving-zookeeper_1
+3c643324066f   federatedai/client:1.8.0-release           "/bin/sh -c 'flow in…"   5 minutes ago   Up 5 minutes             0.0.0.0:20000->20000/tcp, :::20000->20000/tcp                                                                                                   confs-9999_client_1
+3fe0af1ebd71   federatedai/fateboard:1.8.0-release        "/bin/sh -c 'java -D…"   5 minutes ago   Up 5 minutes             0.0.0.0:8080->8080/tcp, :::8080->8080/tcp                                                                                                       confs-9999_fateboard_1
+635b7d99357e   federatedai/python:1.8.0-release           "container-entrypoin…"   5 minutes ago   Up 5 minutes (healthy)   0.0.0.0:9360->9360/tcp, :::9360->9360/tcp, 8080/tcp, 0.0.0.0:9380->9380/tcp, :::9380->9380/tcp                                                  confs-9999_python_1
+8b515f08add3   federatedai/eggroll:1.8.0-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             8080/tcp, 0.0.0.0:9370->9370/tcp, :::9370->9370/tcp                                                                                             confs-9999_rollsite_1
+108cc061c191   federatedai/eggroll:1.8.0-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             4670/tcp, 8080/tcp                                                                                                                              confs-9999_clustermanager_1
+f10575e76899   federatedai/eggroll:1.8.0-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             4671/tcp, 8080/tcp                                                                                                                              confs-9999_nodemanager_1
+aa0a0002de93   mysql:8.0.28                               "docker-entrypoint.s…"   5 minutes ago   Up 5 minutes             3306/tcp, 33060/tcp                                                                                                                             confs-9999_mysql_1
 ```
 
-####  验证部署
+### 验证部署
 
 docker-compose上的FATE启动成功之后需要验证各个服务是否都正常运行，我们可以通过验证toy_example示例来检测。
 
@@ -199,7 +212,7 @@ $ flow test toy --guest-party-id 10000 --host-party-id 9999        #验证
 
 如果测试通过，屏幕将显示类似如下消息：
 
-```
+```bash
 "2019-08-29 07:21:25,353 - secure_add_guest.py[line:96] - INFO: begin to init parameters of secure add example guest"
 "2019-08-29 07:21:25,354 - secure_add_guest.py[line:99] - INFO: begin to make guest data"
 "2019-08-29 07:21:26,225 - secure_add_guest.py[line:102] - INFO: split data into two random parts"
@@ -212,14 +225,18 @@ $ flow test toy --guest-party-id 10000 --host-party-id 9999        #验证
 
 有关测试结果的更多详细信息，请参阅"python/examples/toy_example/README.md"这个文件 。
 
-#### 验证Serving-Service功能
-##### Host方操作
-###### 进入python容器
+### 验证Serving-Service功能
+
+#### Host方操作
+
+##### 进入party10000 client容器
+
 ```bash
 docker exec -it confs-10000_client_1 bash
 ```
 
-###### 修改examples/upload_host.json 
+##### 修改examples/upload_host.json
+
 ```bash
 cat > fateflow/examples/upload/upload_host.json <<EOF
 {
@@ -233,18 +250,22 @@ cat > fateflow/examples/upload/upload_host.json <<EOF
 EOF
 ```
 
-###### 上传数据
+##### 上传host数据
+
 ```bash
 flow data upload -c fateflow/examples/upload/upload_host.json
 ```
 
-##### Guest方操作
-###### 进入python容器
+#### Guest方操作
+
+##### 进入party9999 client容器
+
 ```bash
 docker exec -it confs-9999_client_1 bash
 ```
 
-###### 修改examples/upload_guest.json 
+##### 修改examples/upload_guest.json
+
 ```bash
 cat > fateflow/examples/upload/upload_guest.json <<EOF
 {
@@ -258,12 +279,13 @@ cat > fateflow/examples/upload/upload_guest.json <<EOF
 EOF
 ```
 
-###### 上传数据
+##### 上传guest数据
+
 ```bash
 flow data upload -c fateflow/examples/upload/upload_guest.json
 ```
 
-###### 修改examples/test_hetero_lr_job_conf.json
+##### 修改examples/test_hetero_lr_job_conf.json
 
 ```bash
 cat > fateflow/examples/lr/test_hetero_lr_job_conf.json <<EOF
@@ -476,12 +498,14 @@ cat > fateflow/examples/lr/test_hetero_lr_job_dsl.json <<EOF
 EOF
 ```
 
-###### 提交任务
+##### 提交任务
+
 ```bash
 flow job submit -d fateflow/examples/lr/test_hetero_lr_job_dsl.json -c fateflow/examples/lr/test_hetero_lr_job_conf.json
 ```
 
 output：
+
 ```json
 {
     "data": {
@@ -506,12 +530,14 @@ output：
 }
 ```
 
-###### 查看训练任务状态
+##### 查看训练任务状态
+
 ```bash
 flow task query -r guest -j 202111230933232084530 | grep -w f_status
 ```
 
 output:
+
 ```bash
             "f_status": "success",
             "f_status": "waiting",
@@ -524,7 +550,7 @@ output:
 
 等到所有的`waiting`状态变为`success`.
 
-###### 部署模型
+##### 部署模型
 
 ```bash
 flow model deploy --model-id arbiter-10000#guest-9999#host-10000#model --model-version 202111230933232084530
@@ -572,7 +598,8 @@ flow model deploy --model-id arbiter-10000#guest-9999#host-10000#model --model-v
 
 *后面需要用到的`model_version`都是这一步得到的`"model_version": "202111230954255210490"`*
 
-###### 修改加载模型的配置
+##### 修改加载模型的配置
+
 ```bash
 cat > fateflow/examples/model/publish_load_model.json <<EOF
 {
@@ -599,12 +626,14 @@ cat > fateflow/examples/model/publish_load_model.json <<EOF
 EOF
 ```
 
-###### 加载模型
-```bash 
+##### 加载模型
+
+```bash
 flow model load -c fateflow/examples/model/publish_load_model.json
 ```
 
 output:
+
 ```json
 {
     "data": {
@@ -635,7 +664,8 @@ output:
 }
 ```
 
-###### 修改绑定模型的配置
+##### 修改绑定模型的配置
+
 ```bash
 cat > fateflow/examples/model/bind_model_service.json <<EOF
 {
@@ -658,13 +688,14 @@ cat > fateflow/examples/model/bind_model_service.json <<EOF
 EOF
 ```
 
+##### 绑定模型
 
-###### 绑定模型
 ```bash
 flow model bind -c fateflow/examples/model/bind_model_service.json
 ```
 
 output:
+
 ```json
 {
     "retcode": 0,
@@ -672,7 +703,8 @@ output:
 }
 ```
 
-###### 在线测试
+##### 在线测试
+
 发送以下信息到"GUEST"方的推理服务"{SERVING_SERVICE_IP}:8059/federation/v1/inference"
 
 ```bash
@@ -696,21 +728,25 @@ $ curl -X POST -H 'Content-Type: application/json' -i 'http://192.168.7.2:8059/f
 ```
 
 output:
+
 ```json
 {"retcode":0,"retmsg":"","data":{"score":0.018025086161221948,"modelId":"guest#9999#arbiter-10000#guest-9999#host-10000#model","modelVersion":"202111240318516571130","timestamp":1637743473990},"flag":0}
 ```
+
 ### 删除部署
+
 在部署机器上运行以下命令可以停止所有FATE集群：
+
 ```bash
-./docker_deploy.sh --delete all
+bash ./docker_deploy.sh --delete all
 ```
 
 如果想要彻底删除在运行机器上部署的FATE，可以分别登录节点，然后运行命令：
 
 ```bash
-$ cd /data/projects/fate/confs-<id>/  # <id> 组织的id，本例中代表10000或者9999
-$ docker-compose down
-$ rm -rf ../confs-<id>/               # 删除docker-compose部署文件
+cd /data/projects/fate/confs-<id>/  # <id> 组织的id，本例中代表10000或者9999
+docker-compose down
+rm -rf ../confs-<id>/               # 删除docker-compose部署文件
 ```
 
 ### 可能遇到的问题
@@ -718,7 +754,7 @@ $ rm -rf ../confs-<id>/               # 删除docker-compose部署文件
 #### python容器退出
 
 ```bash
-$ docker exec -it confs-10000_python_1 bash
+docker exec -it confs-10000_python_1 bash
 ```
 
 进入docker容器后马上又弹出来了。
@@ -727,7 +763,7 @@ $ docker exec -it confs-10000_python_1 bash
 
 因为python服务依赖其他所有服务的正常运行，然而第一次启动的时候MySQL需要初始化数据库，python服务的容器会出现几次重启，当MySQL等其他服务都运行正常之后，就可以正常执行了。
 
-#### 采用docker hub下载镜像速度可能较慢。
+#### 采用docker hub下载镜像速度可能较慢
 
 解决办法：可以自己构建镜像，自己构建镜像参考[这里](https://github.com/FederatedAI/FATE/tree/master/docker-build)。
 

--- a/docker-deploy/docker_deploy.sh
+++ b/docker-deploy/docker_deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019-2020 VMware, Inc.
+# Copyright 2019-2022 VMware, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker-deploy/generate_config.sh
+++ b/docker-deploy/generate_config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019-2020 VMware, Inc.
+# Copyright 2019-2022 VMware, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -443,6 +443,8 @@ EOF
 		eval party_id=\${party_list[${i}]}
 		eval party_ip=\${party_ip_list[${i}]}
 		eval serving_ip=\${serving_ip_list[${i}]}
+		eval serving_admin_username=${serving_admin_username}
+		eval serving_admin_password=${serving_admin_password}
 
 		rm -rf serving-$party_id/
 		mkdir -p serving-$party_id/confs
@@ -451,26 +453,22 @@ EOF
 		cp serving_template/docker-compose-serving.yml serving-$party_id/docker-compose.yml
 		if [ "$RegistryURI" != "" ]; then
 			sed -i 's#federatedai#${RegistryURI}/federatedai#g' ./serving-$party_id/docker-compose.yml
-			# should not use federatedai in here
-			sed -i 's#image: "redis:5"#image: "${RegistryURI}/federatedai/redis:5"#g' ./serving-$party_id/docker-compose.yml
 		fi
 		# generate conf dir
 		cp ${WORKINGDIR}/.env ./serving-$party_id
 
+		# serving admin
+		sed -i "s/admin.username=<serving_admin.username>/admin.username=${serving_admin_username}/g" ./serving-$party_id/confs/serving-admin/conf/application.properties
+		sed -i "s/admin.password=<serving_admin.password>/admin.password=${serving_admin_password}/g" ./serving-$party_id/confs/serving-admin/conf/application.properties
+
 		# serving server
-		sed -i "s/127.0.0.1:9380/${party_ip}:9380/g" ./serving-$party_id/confs/serving-server/conf/serving-server.properties
-		sed -i "s/<redis.ip>/${redis_ip}/g" ./serving-$party_id/confs/serving-server/conf/serving-server.properties
-		sed -i "s/<redis.port>/${redis_port}/g" ./serving-$party_id/confs/serving-server/conf/serving-server.properties
-		sed -i "s/<redis.password>/${redis_password}/g" ./serving-$party_id/confs/serving-server/conf/serving-server.properties
-		sed -i "s/<redis.password>/${redis_password}/g" ./serving-$party_id/docker-compose.yml
+		sed -i "s#model.transfer.url=http://127.0.0.1:9380/v1/model/transfer#model.transfer.url=http://${party_ip}:9380/v1/model/transfer#g" ./serving-$party_id/confs/serving-server/conf/serving-server.properties
 
 		# network
 		sed -i "s/name: <fate-network>/name: confs-${party_id}_fate-network/g" serving-$party_id/docker-compose.yml
 		
-		
-
 		# serving proxy
-		sed -i "s/coordinator=9999/coordinator=${party_id}/g" ./serving-$party_id/confs/serving-proxy/conf/application.properties
+		sed -i "s/coordinator=<partyID>/coordinator=${party_id}/g" ./serving-$party_id/confs/serving-proxy/conf/application.properties
 		cat >./serving-$party_id/confs/serving-proxy/conf/route_table.json <<EOF
 {
     "route_table": {
@@ -504,7 +502,7 @@ $(for ((j = 0; j < ${#party_list[*]}; j++)); do
         "default": {
             "default": [
                 {
-                    "ip": "default-serving-proxy",
+                    "ip": "serving-proxy",
                     "port": 8869
                 }
             ]

--- a/docker-deploy/parties.conf
+++ b/docker-deploy/parties.conf
@@ -21,13 +21,12 @@ mysql_user=fate
 mysql_password=fate_dev
 mysql_db=fate_flow
 
-# modify if you are going to use an external redis
-redis_ip=redis
-redis_port=6379
-redis_password=fate_dev
-
 name_node=hdfs://namenode:9000
 
 # Define fateboard login information
 fateboard_username=admin
 fateboard_password=admin
+
+# Define serving admin login information
+serving_admin_username=admin
+serving_admin_password=admin

--- a/docker-deploy/serving_template/docker-compose-serving.yml
+++ b/docker-deploy/serving_template/docker-compose-serving.yml
@@ -1,7 +1,15 @@
-########################################################
-# Copyright 2019-2020 VMware, Inc. #
-# SPDX-License-Identifier: Apache-2.0                  #
-########################################################
+# Copyright 2019-2022 VMware, Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# you may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 version: '3'
 
@@ -15,8 +23,8 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./confs/serving-server/conf/serving-server.properties:/data/projects/fate/serving-server/conf/serving-server.properties
-      - ./confs/serving-server/cache:/data/projects/fate/serving-server/.fate
+      - ./confs/serving-server/conf/serving-server.properties:/data/projects/fate-serving/serving-server/conf/serving-server.properties
+      - ./confs/serving-server/cache:/root/.fate
     networks:
       - fate-serving-network
 
@@ -28,18 +36,8 @@ services:
     expose:
       - 8879
     volumes:
-      - ./confs/serving-proxy/conf/application.properties:/data/projects/fate/serving-proxy/conf/application.properties
-      - ./confs/serving-proxy/conf/route_table.json:/data/projects/fate/serving-proxy/conf/route_table.json
-    networks:
-      - fate-serving-network
-
-  redis:
-    image: "redis:5"
-    expose:
-      - 6379
-    command: redis-server --requirepass <redis.password>
-    volumes:
-      - ./confs/redis/data:/data
+      - ./confs/serving-proxy/conf/application.properties:/data/projects/fate-serving/serving-proxy/conf/application.properties
+      - ./confs/serving-proxy/conf/route_table.json:/data/projects/fate-serving/serving-proxy/conf/route_table.json
     networks:
       - fate-serving-network
 
@@ -59,7 +57,6 @@ services:
     ports:
       - "8350:8350"
     volumes:
-      - ./confs/serving-admin/conf/application.properties:/data/projects/fate/serving-admin/conf/application.properties
-    command: /bin/sh -c "java -cp conf/:lib/*:fate-serving-admin.jar com.webank.ai.fate.serving.admin.Bootstrap -c conf/application.properties"
+      - ./confs/serving-admin/conf/application.properties:/data/projects/fate-serving/serving-admin/conf/application.properties
     networks:
       - fate-serving-network

--- a/docker-deploy/serving_template/docker-serving/serving-admin/conf/application.properties
+++ b/docker-deploy/serving_template/docker-serving/serving-admin/conf/application.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2019 The FATE Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 server.port=8350
 # cache
 #local.cache.expire=300
@@ -10,5 +26,7 @@ zk.url=serving-zookeeper:2181
 # grpc
 #grpc.timeout=5000
 # username & password
-admin.username=admin
-admin.password=admin
+admin.username=<serving_admin.username>
+admin.password=<serving_admin.password>
+
+spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER

--- a/docker-deploy/serving_template/docker-serving/serving-proxy/conf/application.properties
+++ b/docker-deploy/serving_template/docker-serving/serving-proxy/conf/application.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # coordinator same as Party ID
-coordinator=9999
+coordinator=<partyID>
 server.port=8059
 #inference.service.name=serving
 #random, consistent
@@ -23,10 +23,8 @@ server.port=8059
 #auth.file=/data/projects/fate-serving/serving-proxy/conf/auth_config.json
 # zk router
 #useZkRouter=true
-#useRegister=false
-#useZkRouter=false
 zk.url=serving-zookeeper:2181
-#zk.url=localhost:2181,localhost:2182,localhost:2183
+useZkRouter=true
 # zk acl
 #acl.enable=false
 #acl.username=
@@ -35,7 +33,19 @@ zk.url=serving-zookeeper:2181
 #proxy.grpc.intra.port=8879
 # inter-partyid port
 #proxy.grpc.inter.port=8869
+
 # grpc
+# only support PLAINTEXT, TLS(we use Mutual TLS here), if use TSL authentication
+#proxy.grpc.inter.negotiationType=PLAINTEXT
+# only needs to be set when negotiationType is TLS
+#proxy.grpc.inter.CA.file=/data/projects/fate-serving/serving-proxy/conf/ssl/ca.crt
+# negotiated client side certificates
+#proxy.grpc.inter.client.certChain.file=/data/projects/fate-serving/serving-proxy/conf/ssl/client.crt
+#proxy.grpc.inter.client.privateKey.file=/data/projects/fate-serving/serving-proxy/conf/ssl/client.pem
+# negotiated server side certificates
+#proxy.grpc.inter.server.certChain.file=/data/projects/fate-serving/serving-proxy/conf/ssl/server.crt
+#proxy.grpc.inter.server.privateKey.file=/data/projects/fate-serving/serving-proxy/conf/ssl/server.pem
+
 #proxy.grpc.inference.timeout=3000
 #proxy.grpc.inference.async.timeout=1000
 #proxy.grpc.unaryCall.timeout=3000

--- a/docker-deploy/serving_template/docker-serving/serving-server/conf/serving-server.properties
+++ b/docker-deploy/serving_template/docker-serving/serving-server/conf/serving-server.properties
@@ -18,18 +18,18 @@ port=8000
 # cache
 #remoteModelInferenceResultCacheSwitch=false
 #cache.type=local
-#model.cache.path=
+#model.cache.path=/data/projects/fate-serving/serving-server
 # local cache
 #local.cache.maxsize=10000
 #local.cache.expire=30
 #local.cache.interval=3
 # external cache
-redis.ip=<redis.ip>
-redis.port=<redis.port>
+#redis.ip=
+#redis.port=
 ### configure this parameter to use cluster mode
 #redis.cluster.nodes=127.0.0.1:6379,127.0.0.1:6380,127.0.0.1:6381,127.0.0.1:6382,127.0.0.1:6383,127.0.0.1:6384
 ### this password is common in stand-alone mode and cluster mode
-redis.password=<redis.password>
+#redis.password=
 #redis.timeout=10
 #redis.expire=3000
 #redis.maxTotal=100
@@ -39,6 +39,7 @@ proxy=serving-proxy:8879
 # adapter
 feature.single.adaptor=com.webank.ai.fate.serving.adaptor.dataaccess.MockAdapter
 feature.batch.adaptor=com.webank.ai.fate.serving.adaptor.dataaccess.MockBatchAdapter
+http.adapter.url=http://127.0.0.1:9380/v1/http/adapter/getFeature
 # model transfer
 model.transfer.url=http://127.0.0.1:9380/v1/model/transfer
 # zk router
@@ -49,3 +50,7 @@ useZkRouter=true
 #acl.enable=false
 #acl.username=
 #acl.password=
+
+# LR algorithm config
+#lr.split.size=500
+#lr.use.parallel=false

--- a/helm-charts/FATE-Serving/Chart.yaml
+++ b/helm-charts/FATE-Serving/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v2.0.4
+appVersion: v2.1.5
 description: A Helm chart for FATE-Serving
 name: fate-serving
-version: v2.0.4
+version: v2.1.5
 sources:
   - https://github.com/FederatedAI/KubeFATE
   - https://github.com/FederatedAI/FATE-Serving

--- a/helm-charts/FATE-Serving/templates/ingress.yaml
+++ b/helm-charts/FATE-Serving/templates/ingress.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 VMware, Inc.
+# Copyright 2019-2022 VMware, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 {{ if .Values.servingProxy.include }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: serving-proxy
@@ -25,15 +25,19 @@ metadata:
 {{ toYaml .Values.ingress.servingProxy.annotations | indent 4 }}
 {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingressClassName }}
   rules:
   {{- range .Values.ingress.servingProxy.hosts }}
   - host: {{ .name }}
     http:
       paths:
       - path: {{ default "/" .path }}
+        pathType: Prefix
         backend:
-          serviceName: serving-proxy
-          servicePort: 8059
+          service:
+            name: serving-proxy
+            port: 
+              number: 8059
   {{- end }}
 {{- if .Values.ingress.servingProxy.tls }}
   tls:
@@ -43,7 +47,7 @@ spec:
 {{ end }}
 
 {{ if .Values.servingAdmin.include }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: serving-admin
@@ -58,15 +62,19 @@ metadata:
 {{ toYaml .Values.ingress.servingAdmin.annotations | indent 4 }}
 {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingressClassName }}
   rules:
   {{- range .Values.ingress.servingAdmin.hosts }}
-    - host: {{ .name }}
-      http:
-        paths:
-          - path: {{ default "/" .path }}
-            backend:
-              serviceName: serving-admin
-              servicePort: 8350
+  - host: {{ .name }}
+    http:
+      paths:
+      - path: {{ default "/" .path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: serving-admin
+            port: 
+              number: 8350
   {{- end }}
 {{- if .Values.ingress.servingAdmin.tls }}
   tls:

--- a/helm-charts/FATE-Serving/templates/serving-admin-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-admin-module.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 VMware, Inc.
+# Copyright 2019-2022 VMware, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -36,6 +36,8 @@ data:
     # username & password
     admin.username={{ .Values.servingAdmin.username }}
     admin.password={{ .Values.servingAdmin.password }}
+
+    spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -71,13 +73,8 @@ spec:
           name: serving-admin
           ports:
             - containerPort: 8350
-          command:
-            - sh
-            - -c
-            - |
-              java -cp conf/:lib/*:fate-serving-admin.jar com.webank.ai.fate.serving.admin.Bootstrap -c conf/application.properties
           volumeMounts:
-            - mountPath: /data/projects/fate/serving-admin/conf/application.properties
+            - mountPath: /data/projects/fate-serving/serving-admin/conf/application.properties
               name: serving-admin-confs
               subPath: application.properties
       {{- with .Values.servingAdmin.nodeSelector }}

--- a/helm-charts/FATE-Serving/templates/serving-proxy-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-proxy-module.yaml
@@ -43,12 +43,12 @@ data:
     #inference.service.name=serving
     #random, consistent
     #routeType=random
-    route.table=/data/projects/fate/serving-proxy/conf/route_table/route_table.json
-    #auth.file=/data/projects/fate/serving-proxy/conf/auth_config.json
+    #route.table=/data/projects/fate-serving/serving-proxy/conf/route_table.json
+    #auth.file=/data/projects/fate-serving/serving-proxy/conf/auth_config.json
     # zk router
-    useZkRouter=true
-    useRegister=true
+    #useZkRouter=true
     zk.url=serving-zookeeper:2181
+    useZkRouter=true
     # zk acl
     #acl.enable=false
     #acl.username=
@@ -57,7 +57,19 @@ data:
     #proxy.grpc.intra.port=8879
     # inter-partyid port
     #proxy.grpc.inter.port=8869
+
     # grpc
+    # only support PLAINTEXT, TLS(we use Mutual TLS here), if use TSL authentication
+    #proxy.grpc.inter.negotiationType=PLAINTEXT
+    # only needs to be set when negotiationType is TLS
+    #proxy.grpc.inter.CA.file=/data/projects/fate-serving/serving-proxy/conf/ssl/ca.crt
+    # negotiated client side certificates
+    #proxy.grpc.inter.client.certChain.file=/data/projects/fate-serving/serving-proxy/conf/ssl/client.crt
+    #proxy.grpc.inter.client.privateKey.file=/data/projects/fate-serving/serving-proxy/conf/ssl/client.pem
+    # negotiated server side certificates
+    #proxy.grpc.inter.server.certChain.file=/data/projects/fate-serving/serving-proxy/conf/ssl/server.crt
+    #proxy.grpc.inter.server.privateKey.file=/data/projects/fate-serving/serving-proxy/conf/ssl/server.pem
+
     #proxy.grpc.inference.timeout=3000
     #proxy.grpc.inference.async.timeout=1000
     #proxy.grpc.unaryCall.timeout=3000
@@ -79,7 +91,7 @@ data:
                     "ip": "{{ .partyIp }}",
                     "port": {{ .partyPort }}
                   {{- else }}
-                    "ip": "default-serving-proxy",
+                    "ip": "serving-proxy",
                     "port": 8869
                   {{- end }}
                 }
@@ -151,12 +163,22 @@ spec:
           ports:
             - containerPort: 8059
             - containerPort: 8869
+          command:
+          - /bin/sh
+          - -c
+          - |
+            # make route_table.json editable
+            cp /data/projects/fate-serving/serving-proxy/conf/route_table.base.json /data/projects/fate-serving/serving-proxy/conf/route_table.json
+            chmod 755 /data/projects/fate-serving/serving-proxy/conf/route_table.json
+
+            java -Dspring.config.location=conf/application.properties -cp conf/:lib/*:fate-serving-proxy.jar com.webank.ai.fate.serving.proxy.bootstrap.Bootstrap -c conf/application.properties
           volumeMounts:
-            - mountPath: /data/projects/fate/serving-proxy/conf/application.properties
+            - mountPath: /data/projects/fate-serving/serving-proxy/conf/application.properties
               name: serving-proxy-confs
               subPath: application.properties
-            - mountPath: /data/projects/fate/serving-proxy/conf/route_table
+            - mountPath: /data/projects/fate-serving/serving-proxy/conf/route_table.base.json
               name: serving-proxy-confs
+              subPath: route_table.json
       {{- with .Values.servingProxy.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm-charts/FATE-Serving/templates/serving-server-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-server-module.yaml
@@ -26,9 +26,9 @@ data:
     port=8000
     #serviceRoleName=serving
     # cache
-    #remoteModelInferenceResultCacheSwitch=false
+    remoteModelInferenceResultCacheSwitch={{ .Values.servingServer.cacheSwitch | default "false" }}
     cache.type={{ .Values.servingServer.cacheType | default "local" }}
-    model.cache.path=/root/.fate
+    model.cache.path=/data/projects/fate-serving/serving-server
     # local cache
     #local.cache.maxsize=10000
     #local.cache.expire=30
@@ -46,11 +46,12 @@ data:
     #redis.expire=3000
     #redis.maxTotal=100
     #redis.maxIdle=100
-    # external subsystem
-    #proxy={{ .Values.servingProxy.ip }}:8879
+
+    proxy={{ .Values.servingProxy.ip }}:8879
     # adapter
-    feature.single.adaptor=com.webank.ai.fate.serving.adaptor.dataaccess.MockAdapter
-    feature.batch.adaptor=com.webank.ai.fate.serving.adaptor.dataaccess.MockBatchAdapter
+    feature.single.adaptor={{ .Values.servingServer.singleAdaptor | default "com.webank.ai.fate.serving.adaptor.dataaccess.MockAdapter" }}
+    feature.batch.adaptor={{ .Values.servingServer.batchAdaptor | default "com.webank.ai.fate.serving.adaptor.dataaccess.MockBatchAdapter" }}
+    http.adapter.url={{ .Values.servingServer.AdapterURL | default "http://127.0.0.1:9380/v1/http/adapter/getFeature" }}
     # model transfer
     model.transfer.url=http://{{ .Values.servingServer.fateflow.ip }}:{{ .Values.servingServer.fateflow.port }}/v1/model/transfer
     # zk router
@@ -61,6 +62,11 @@ data:
     #acl.enable=false
     #acl.username=
     #acl.password=
+
+    # LR algorithm config
+    #lr.split.size=500
+    #lr.use.parallel=false
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -97,7 +103,7 @@ spec:
           ports:
             - containerPort: 9394
           volumeMounts:
-            - mountPath: /data/projects/fate/serving-server/conf/serving-server.properties
+            - mountPath: /data/projects/fate-serving/serving-server/conf/serving-server.properties
               name: serving-server-confs
               subPath: serving-server.properties
             - name: data

--- a/helm-charts/FATE-Serving/values-template-example.yaml
+++ b/helm-charts/FATE-Serving/values-template-example.yaml
@@ -1,10 +1,10 @@
 name: fate-serving-10000
 namespace: fate-serving-10000
 chartName: fate-serving
-chartVersion: v2.0.4
+chartVersion: v2.1.5
 partyId: 10000
 registry: ""
-imageTag: ""
+imageTag: "2.1.5-release"
 pullPolicy: 
 imagePullSecrets: 
 - name: myregistrykey
@@ -13,6 +13,7 @@ istio:
   enabled: false
 podSecurityPolicy:
   enabled: false
+ingressClassName: nginx
 modules:
   - servingProxy
   - servingRedis
@@ -72,8 +73,12 @@ ingress:
   # fateflow:
     # ip: 192.168.10.1
     # port: 30110
+  # cacheSwitch: true
+  # cacheType: "redis"
+  # singleAdaptor: com.webank.ai.fate.serving.adaptor.dataaccess.MockAdapter
+  # batchAdaptor: com.webank.ai.fate.serving.adaptor.dataaccess.MockBatchAdapter
+  # AdapterURL: http://127.0.0.1:9380/v1/http/adapter/getFeature
   # subPath: ""
-  # cacheType: "local"
   # existingClaim: ""
   # storageClass: "serving-server"
   # accessMode: ReadWriteOnce

--- a/helm-charts/FATE-Serving/values-template.yaml
+++ b/helm-charts/FATE-Serving/values-template.yaml
@@ -6,7 +6,7 @@ partyName: {{ .name }}
 image:
   registry: {{ .registry | default "federatedai" }}
   isThridParty: {{ empty .registry | ternary  "false" "true" }}
-  tag: {{ .imageTag | default "2.0.4-release" }}
+  tag: {{ .imageTag | default "2.1.5-release" }}
   pullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
   {{- with .imagePullSecrets }}
   imagePullSecrets:
@@ -26,6 +26,7 @@ podSecurityPolicy:
   enabled: {{ .enabled | default false }}
 {{- end }}
 
+ingressClassName: {{ .ingressClassName | default "nginx"}}
 
 {{- with .ingress }}
 ingress:
@@ -70,8 +71,6 @@ servingProxy:
   type: {{ .type }}
   nodePort: {{ .nodePort }}
   loadBalancerIP: {{ .loadBalancerIP }}
-  ingerssHost: {{ .ingressHost | default (printf "%s.serving-admin.example.com" $partyId) }}
-
   {{- with .partyList }}
   partyList:
   {{- range . }}
@@ -104,7 +103,7 @@ servingProxy:
 
 servingRedis:
   include: {{ has "servingRedis" .modules }}
-  
+
   {{- with .servingRedis }}
 
   password: {{ .password | default "fate_dev" }}
@@ -144,12 +143,17 @@ servingServer:
     port: {{ .port }}
   {{- end }}
   
+  cacheSwitch: {{ .cacheType | default "false" }}
+  cacheType: {{ .cacheType | default "local" }}
+  singleAdaptor: {{ .singleAdaptor | default "com.webank.ai.fate.serving.adaptor.dataaccess.MockAdapter" }}
+  batchAdaptor: {{ .batchAdaptor | default "com.webank.ai.fate.serving.adaptor.dataaccess.MockBatchAdapter" }}
+  AdapterURL: {{ .AdapterURL | default "http://127.0.0.1:9380/v1/http/adapter/getFeature" }}
+
   subPath: {{ .subPath }}
   existingClaim: {{ .existingClaim }}
   storageClass: {{ .storageClass | default "serving-redis" }}
   accessMode: {{ .accessMode | default "ReadWriteOnce" }}
   size: {{ .size | default "1Gi" }}
-  cacheType: {{ .cacheType | default "local" }}
   {{- with .nodeSelector }}
   nodeSelector:
 {{ toYaml . | indent 4 }}

--- a/helm-charts/FATE-Serving/values.yaml
+++ b/helm-charts/FATE-Serving/values.yaml
@@ -5,7 +5,7 @@ partyName: fate-serving-9999
 image:
   registry: federatedai
   isThridParty:
-  tag: 2.0.4-release
+  tag: 2.1.5-release
   pullPolicy: IfNotPresent
   imagePullSecrets: 
 #  - name: 
@@ -18,6 +18,7 @@ istio:
 podSecurityPolicy:
   enabled: false
 
+ingressClassName: nginx
 
 ingress:
   servingProxy: 
@@ -57,18 +58,6 @@ servingProxy:
     # partyIp: 192.168.10.1
     # partyPort: 30110
 
-servingRedis:
-  include: true
-  password: fate_dev
-  subPath: ""
-  existingClaim: ""
-  storageClass: "serving-redis"
-  accessMode: ReadWriteOnce
-  size: 1Gi
-  nodeSelector:
-  tolerations:
-  affinity:
-  
 servingServer:
   include: true
   type: NodePort
@@ -80,13 +69,16 @@ servingServer:
   nodeSelector:
   tolerations:
   affinity:
+  cacheSwitch: false
+  cacheType: redis
+  singleAdaptor: com.webank.ai.fate.serving.adaptor.dataaccess.MockAdapter
+  batchAdaptor: com.webank.ai.fate.serving.adaptor.dataaccess.MockBatchAdapter
+  AdapterURL: http://127.0.0.1:9380/v1/http/adapter/getFeature
   subPath: ""
   existingClaim: ""
   storageClass: "serving-server"
   accessMode: ReadWriteOnce
-  cacheType: local
   size: 1Gi
-
 
 servingZookeeper:
   include: true
@@ -99,7 +91,6 @@ servingZookeeper:
   accessMode: ReadWriteOnce
   size: 1Gi
 
-
 servingAdmin:
   include: true
   username: admin
@@ -107,6 +98,19 @@ servingAdmin:
   nodeSelector: 
   tolerations:
   affinity:
+
+servingRedis:
+  include: true
+  password: fate_dev
+  subPath: ""
+  existingClaim: ""
+  storageClass: "serving-redis"
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  nodeSelector:
+  tolerations:
+  affinity:
+
 
 # externalRedisIp: "redis"
 # externalRedisPort: 6379

--- a/helm-charts/FATE/templates/psp.yaml
+++ b/helm-charts/FATE/templates/psp.yaml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.podSecurityPolicy.enabled -}}
+{{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -29,4 +29,4 @@ spec:
     rule: RunAsAny
   volumes:
   - '*'
-{{- end -}}
+{{- end }}

--- a/helm-charts/FATE/templates/role.yaml
+++ b/helm-charts/FATE/templates/role.yaml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.podSecurityPolicy.enabled  -}}
+{{- if .Values.podSecurityPolicy.enabled  }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -22,4 +22,4 @@ rules:
     resources:      ['podsecuritypolicies']
     verbs:          ['use']
     resourceNames:  [{{ .Values.partyName }}]
-{{- end -}}
+{{- end }}

--- a/helm-charts/FATE/templates/rolebinding.yaml
+++ b/helm-charts/FATE/templates/rolebinding.yaml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.podSecurityPolicy.enabled -}}
+{{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -25,4 +25,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.partyName }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}

--- a/helm-charts/FATE/templates/serviceaccount.yaml
+++ b/helm-charts/FATE/templates/serviceaccount.yaml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.podSecurityPolicy.enabled -}}
+{{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -17,4 +17,4 @@ metadata:
     fateMoudle: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
-{{- end -}}
+{{- end }}

--- a/k8s-deploy/cluster-serving.yaml
+++ b/k8s-deploy/cluster-serving.yaml
@@ -1,10 +1,10 @@
 name: fate-serving-9999
 namespace: fate-serving-9999
 chartName: fate-serving
-chartVersion: v2.0.4
+chartVersion: v2.1.5
 partyId: 9999
 registry: ""
-imageTag: ""
+imageTag: "2.1.5-release"
 pullPolicy: 
 imagePullSecrets: 
 - name: myregistrykey
@@ -24,21 +24,21 @@ modules:
   # servingProxy: 
     # # annotations: 
     # hosts:
-    # - name: serving-proxy.example.com
+    # - name: party9999.serving-proxy.example.com
       # path: /
   # # tls:
     # # - secretName: my-tls-secret
       # # hosts:
-        # # - serving-proxy.example.com
+        # # - party9999.serving-proxy.example.com
   # servingAdmin: 
     # # annotations: 
     # hosts:
-    # - name: serving-admin.example.com
+    # - name: party9999.serving-admin.example.com
       # path: /
   # # tls:
     # # - secretName: my-tls-secret
       # # hosts:
-         # # - serving-admin.example.com
+         # # - party9999.serving-admin.example.com
 
 # servingAdmin:
   # nodeSelector:
@@ -50,13 +50,14 @@ modules:
 # servingProxy: 
   # nodePort: 30310
   # type: NodePort
+  # loadBalancerIP: 
   # nodeSelector:
   # tolerations:
   # affinity:
   # partyList:
-  # # - partyId: 10000
-    # # partyIp: 192.168.10.1
-    # # partyPort: 30310
+  # # - partyId: 9999
+    # # partyIp: 192.168.9.1
+    # # partyPort: 30309
   # exchange:
     # ip: 192.168.1.1
     # port: 30100
@@ -64,12 +65,18 @@ modules:
 # servingServer:
   # type: NodePort
   # nodePort: 30210
+  # loadBalancerIP: 
   # nodeSelector:
   # tolerations:
   # affinity:
   # fateflow:
-    # ip: 192.168.9.1
-    # port: 30109
+    # ip: 192.168.10.1
+    # port: 30110
+  # cacheSwitch: true
+  # cacheType: "redis"
+  # singleAdaptor: com.webank.ai.fate.serving.adaptor.dataaccess.MockAdapter
+  # batchAdaptor: com.webank.ai.fate.serving.adaptor.dataaccess.MockBatchAdapter
+  # AdapterURL: http://127.0.0.1:9380/v1/http/adapter/getFeature
   # subPath: ""
   # existingClaim: ""
   # storageClass: "serving-server"

--- a/k8s-deploy/examples/party-10000/cluster-serving.yaml
+++ b/k8s-deploy/examples/party-10000/cluster-serving.yaml
@@ -1,10 +1,10 @@
 name: fate-serving-10000
 namespace: fate-serving-10000
 chartName: fate-serving
-chartVersion: v2.0.4
+chartVersion: v2.1.5
 partyId: 10000
 registry: ""
-imageTag: 2.0.4-release
+imageTag: 2.1.5-release
 pullPolicy: 
 imagePullSecrets: 
 - name: myregistrykey
@@ -13,6 +13,7 @@ istio:
   enabled: false
 podSecurityPolicy:
   enabled: false
+ingressClassName: nginx
 modules:
   - servingProxy
   - servingRedis
@@ -41,7 +42,6 @@ servingProxy:
   - partyId: 9999
     partyIp: 192.168.9.1
     partyPort: 30096
-  nodeSelector: {}
 
 servingServer:
   type: NodePort
@@ -49,25 +49,9 @@ servingServer:
   fateflow:
     ip: 192.168.10.1
     port: 30107
-  subPath: ""
-  existingClaim: ""
-  storageClass: "serving-server"
-  accessMode: ReadWriteOnce
-  size: 1Gi
-  nodeSelector: {}
-
-servingRedis:
-  password: fate_dev
-  nodeSelector: {}
-  subPath: ""
-  existingClaim: ""
-  storageClass: "serving-redis"
-  accessMode: ReadWriteOnce
-  size: 1Gi
-
-servingZookeeper:
-  subPath: ""
-  existingClaim: ""
-  storageClass: "serving-zookeeper"
-  accessMode: ReadWriteOnce
-  size: 1Gi
+  cacheSwitch: true
+  cacheType: "redis"
+  singleAdaptor: com.webank.ai.fate.serving.adaptor.dataaccess.MockAdapter
+  batchAdaptor: com.webank.ai.fate.serving.adaptor.dataaccess.MockBatchAdapter
+  AdapterURL: http://127.0.0.1:9380/v1/http/adapter/getFeature
+  

--- a/k8s-deploy/examples/party-9999/cluster-serving.yaml
+++ b/k8s-deploy/examples/party-9999/cluster-serving.yaml
@@ -1,10 +1,10 @@
 name: fate-serving-9999
 namespace: fate-serving-9999
 chartName: fate-serving
-chartVersion: v2.0.4
+chartVersion: v2.1.5
 partyId: 9999
 registry: ""
-imageTag: 2.0.4-release
+imageTag: 2.1.5-release
 pullPolicy: 
 imagePullSecrets: 
 - name: myregistrykey
@@ -13,6 +13,7 @@ istio:
   enabled: false
 podSecurityPolicy:
   enabled: false
+ingressClassName: nginx
 modules:
   - servingProxy
   - servingRedis
@@ -41,7 +42,6 @@ servingProxy:
   - partyId: 10000
     partyIp: 192.168.10.1
     partyPort: 30106
-  nodeSelector: {}
 
 servingServer:
   type: NodePort
@@ -49,25 +49,9 @@ servingServer:
   fateflow:
     ip: 192.168.9.1
     port: 30097
-  subPath: ""
-  existingClaim: ""
-  storageClass: "serving-server"
-  accessMode: ReadWriteOnce
-  size: 1Gi
-  nodeSelector: {}
-
-servingRedis:
-  password: fate_dev
-  nodeSelector: {}
-  subPath: ""
-  existingClaim: ""
-  storageClass: "serving-redis"
-  accessMode: ReadWriteOnce
-  size: 1Gi
-
-servingZookeeper:
-  subPath: ""
-  existingClaim: ""
-  storageClass: "serving-zookeeper"
-  accessMode: ReadWriteOnce
-  size: 1Gi
+  cacheSwitch: true
+  cacheType: "redis"
+  singleAdaptor: com.webank.ai.fate.serving.adaptor.dataaccess.MockAdapter
+  batchAdaptor: com.webank.ai.fate.serving.adaptor.dataaccess.MockBatchAdapter
+  AdapterURL: http://127.0.0.1:9380/v1/http/adapter/getFeature
+  

--- a/k8s-deploy/examples/party.config
+++ b/k8s-deploy/examples/party.config
@@ -1,7 +1,7 @@
 fate_chartVersion=v1.8.0
 fate_imageTAG=1.8.0-release
-fate_serving_chartVersion=v2.0.4
-fate_serving_imageTAG=2.0.4-release
+fate_serving_chartVersion=v2.1.5
+fate_serving_imageTAG=2.1.5-release
 party_9999_IP=192.168.9.1
 party_10000_IP=192.168.10.1
 party_exchange_IP=192.168.0.1


### PR DESCRIPTION
* feat docker-compose support FATE-Serving v2.1.5

Signed-off-by: Chenlong Ma <chenlongm@vmware.com>

* feat: k8s support FATE-Serving v2.1.5

Signed-off-by: Chenlong Ma <chenlongm@vmware.com>

* chart of fate-serving support ingressClass

Signed-off-by: Chenlong Ma <chenlongm@vmware.com>

* fix base path of fate-serving

Signed-off-by: Chenlong Ma <chenlongm@vmware.com>

* fix base path of fate-serving.
add cacheSwitch
rm redis form docker-compose

Signed-off-by: Chenlong Ma <chenlongm@vmware.com>

* fix route_table read only

Signed-off-by: Chenlong Ma <chenlongm@vmware.com>

* fix fate-serving chart lint

Signed-off-by: Chenlong Ma <chenlongm@vmware.com>

* fix CI of docker deploy

Signed-off-by: Chenlong Ma <chenlongm@vmware.com>

* fix if podSecurityPolicy.enabled is true getting error 'helm install error, unable to build kubernetes objects from release manifest: error validating "": error validating data: apiVersion not set'

Signed-off-by: Chenlong Ma <chenlongm@vmware.com>

Co-authored-by: owlet42 <owlet42@126.com>

Fixes  ISSUE#xxx

Changes:

1.

2.

3.


