### PR TITLE
Do not let datanodes to share one pvc 

### DIFF
--- a/helm-charts/FATE/templates/backends/spark/hdfs/datanode.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/datanode.yaml
@@ -99,7 +99,7 @@ spec:
       volumes:
         - name: dfs
           emptyDir: {}
-      {{ else if .Values.persistence.enabled and .Values.modules.hdfs.datanode.existingClaim }}
+      {{ else if and .Values.persistence.enabled (.Values.modules.hdfs.datanode.existingClaim) }}
       volumes:
         - name: dfs
           persistentVolumeClaim:

--- a/helm-charts/FATE/templates/backends/spark/hdfs/datanode.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/datanode.yaml
@@ -95,12 +95,27 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "serviceAccountName" . }}
       restartPolicy: Always
+      {{ if not .Values.persistence.enabled }}
       volumes:
         - name: dfs
-        {{ if .Values.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.modules.hdfs.datanode.existingClaim | default  "datanode-data" }}
-        {{ else }}
           emptyDir: {}
-        {{ end }}
+      {{ else if .Values.persistence.enabled and .Values.modules.hdfs.datanode.existingClaim }}
+      volumes:
+        - name: dfs
+          persistentVolumeClaim:
+            claimName: {{ .Values.modules.hdfs.datanode.existingClaim }}
+      {{ else }}
+  volumeClaimTemplates:
+    - metadata:
+        name: dfs
+        labels:
+          fateMoudle: datanode
+          {{ include "fate.labels" . | indent 10 }}
+      spec:
+        accessModes: [{{ .Values.modules.hdfs.datanode.accessMode }}]
+        storageClassName: {{ .Values.modules.hdfs.datanode.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.modules.hdfs.datanode.size }}
+      {{ end }}
 {{ end }}

--- a/helm-charts/FATE/templates/backends/spark/hdfs/datanode.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/datanode.yaml
@@ -110,7 +110,7 @@ spec:
         name: dfs
         labels:
           fateMoudle: datanode
-          {{ include "fate.labels" . | indent 10 }}
+{{ include "fate.labels" . | indent 10 }}
       spec:
         accessModes: [{{ .Values.modules.hdfs.datanode.accessMode }}]
         storageClassName: {{ .Values.modules.hdfs.datanode.storageClass }}

--- a/helm-charts/FATE/templates/backends/spark/hdfs/persistentvolumeclaim.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/persistentvolumeclaim.yaml
@@ -32,28 +32,4 @@ spec:
     {{ end }}
   {{ end }}
 {{ end }}
----
-{{ if and .Values.persistence.enabled (not .Values.modules.hdfs.datanode.existingClaim) }}
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: datanode-data
-  labels:
-    fateMoudle: datanode
-{{ include "fate.labels" . | indent 4 }}
-spec:
-  accessModes:
-    - {{ .Values.modules.hdfs.datanode.accessMode }}
-  resources:
-    requests:
-      storage: {{ .Values.modules.hdfs.datanode.size }}
-  {{ if .Values.modules.hdfs.datanode.storageClass }}
-    {{ if eq "-" .Values.modules.hdfs.datanode.storageClass }}
-  storageClassName: ""
-    {{ else }}
-  storageClassName: {{ .Values.modules.hdfs.datanode.storageClass }}
-    {{ end }}
-  {{ end }}
-{{ end }}
-
 {{ end }}

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -149,7 +149,7 @@ backend: eggroll
   # enabledNN: false
   # logLevel: INFO
   # existingClaim: ""
-  # storageClass: "python"
+  # s: "python"
   # accessMode: ReadWriteMany
   # size: 1Gi
   # clustermanager:
@@ -268,12 +268,20 @@ backend: eggroll
     # affinity:
     # type: ClusterIP
     # nodePort: 30900
+    # existingClaim:
+    # storageClass:
+    # accessMode:
+    # size:
   # datanode:
     # replicas:
     # nodeSelector:
     # tolerations:
     # affinity:
     # type: ClusterIP
+    # existingClaim:
+    # storageClass:
+    # accessMode:
+    # size:
 # nginx:
   # nodeSelector:
   # tolerations:

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -149,7 +149,7 @@ backend: eggroll
   # enabledNN: false
   # logLevel: INFO
   # existingClaim: ""
-  # s: "python"
+  # storageClass: "python"
   # accessMode: ReadWriteMany
   # size: 1Gi
   # clustermanager:

--- a/helm-charts/FATE/values.yaml
+++ b/helm-charts/FATE/values.yaml
@@ -276,12 +276,20 @@ modules:
       affinity:
       type: ClusterIP
       nodePort: 30900
+      existingClaim:
+      storageClass:
+      accessMode:
+      size:
     datanode:
       replicas: 3
       nodeSelector:
       tolerations:
       affinity:
       type: ClusterIP
+      existingClaim:
+      storageClass:
+      accessMode:
+      size:
   nginx:
     include: true
     nodeSelector:


### PR DESCRIPTION
Fixes  ISSUE#649

## Description
Before this change, 3 hdfs datanodes are sharing 1 pvc,
After this change, 3 hdfs datanodes have their own pvc respectively.

## Test
1. When persistence is disabled, verified the final applied yaml file is like:
```
disable persistence:

      volumes:
        - name: dfs
          emptyDir: {}
```

2. When persisitence is enabled, verified that the applied yaml file is like:
```
  volumeClaimTemplates:
    - metadata:
        name: dfs
        labels:
          fateMoudle: datanode
          name: "fate-9999"
          partyId: "9999"
          owner: kubefate
          cluster: fate
          heritage: Helm
          release: release-name
          chart: fate
      spec:
        accessModes: [ReadWriteOnce]
        storageClassName: standard
        resources:
          requests:
            storage: 10Gi
```
And verified that finally each datenode has a pvc:
```
07:40:05 root@control-plane k8s-deploy ±|fix-issue-649 ✗|→ kg pvc -A
NAMESPACE   NAME             STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
fate-9999   dfs-datanode-0   Bound     pvc-2e8a8c6d-7b30-4227-bf3a-567ec33eec93   10Gi       RWO            standard       111s
fate-9999   dfs-datanode-1   Bound     pvc-8c4d36c7-cb1c-4cf3-88a5-19c18fd0b528   10Gi       RWO            standard       62s
fate-9999   dfs-datanode-2   Bound     pvc-09fdb1f8-098d-43da-bd80-0670159713c4   10Gi       RWO            standard       47s
```
3. When persistence is enabled and there is an existing claim, verified the final yaml file is expected:
```
    volumes:
      - name: dfs
        persistentVolumeClaim:
          claimName: blabla
```


