### PR TITLE
alert user if the modules not match backend

### DIFF
--- a/k8s-deploy/pkg/cli/cluster_cli.go
+++ b/k8s-deploy/pkg/cli/cluster_cli.go
@@ -164,13 +164,13 @@ func ClusterInstallCommand() *cli.Command {
 			}
 
 			if template, err := GetValueTemplateExample(chartName.(string), chartVersion.(string)); err != nil {
-				color.Yellow("Config Warning: %s", err.Error())
+				color.Yellow("Config Warning: %s\n", err.Error())
 			} else {
 				skippedKeys := getSkippedKeys(m)
 				errs := ValidateYaml(template, string(clusterConfig), skippedKeys)
 				for _, err := range errs {
 					if err != nil {
-						color.Yellow("Config Warning: %s", err.Error())
+						color.Yellow("Config Warning: %s\n", err.Error())
 					}
 				}
 			}

--- a/k8s-deploy/pkg/cli/validation_test.go
+++ b/k8s-deploy/pkg/cli/validation_test.go
@@ -254,7 +254,7 @@ func TestValidateYaml(t *testing.T) {
 		{"validateEmptyYaml", args{"", "", nil}, []error{errors.New("template or test yaml is empty")}},
 		{"validateSameYaml", args{s1, s1, nil}, []error{}},
 		{"validateValidYaml", args{s1, s2, nil}, []error{}},
-		{"validateNotValidYaml", args{s1, s3, nil}, []error{errors.New("Your yaml at '/a/d', line 8 \n  'd: 3' may be redundant\n")}},
+		{"validateNotValidYaml", args{s1, s3, nil}, []error{errors.New("your yaml at '/a/d', line 8 \n  'd: 3' may be redundant")}},
 		{"validateYamlWithskippedKeys", args{s1, s4, []string{"d"}}, []error{}},
 	}
 	for _, tt := range tests {

--- a/k8s-deploy/pkg/cli/validation_test.go
+++ b/k8s-deploy/pkg/cli/validation_test.go
@@ -6,11 +6,6 @@ import (
 	"testing"
 )
 
-const (
-	_templateFilename = "../../../helm-charts/FATE/values-template-example.yaml"
-	_testFilename     = "../../examples/party-10000/cluster.yaml"
-)
-
 var (
 	s0 = `
 chartName: fate
@@ -54,6 +49,22 @@ skippedKeys:
 a:
   b: 2
   d: 3
+`
+
+	s5 = `
+backend: eggroll
+modules:
+  - rollsite
+  - clustermanager
+python: 
+`
+
+	s6 = `
+backend: spark_rabbitmq
+modules:
+  - pulsar
+  - rabbitmq
+rollsite: 
 `
 )
 
@@ -277,6 +288,26 @@ func Test_getSkippedKeys(t *testing.T) {
 			if gotSkippedKeys := getSkippedKeys(tt.args.m); !reflect.DeepEqual(gotSkippedKeys, tt.wantSkippedKeys) {
 				t.Errorf("getSkippedKeys() = %v, want %v", gotSkippedKeys, tt.wantSkippedKeys)
 			}
+		})
+	}
+}
+
+func Test_alertUserIfModulesNotMatchBackend(t *testing.T) {
+	type args struct {
+		yamlMap map[string]interface{}
+	}
+	yamlMap1, _ := bufferToMap([]byte(s5))
+	yamlMap2, _ := bufferToMap([]byte(s6))
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"correct", args{yamlMap1}},
+		{"redundant", args{yamlMap2}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alertUserIfModulesNotMatchBackend(tt.args.yamlMap)
 		})
 	}
 }


### PR DESCRIPTION
Fixes ISSUE #517 

## Description
1. Different backend has different modules.If one module doesn't match its backend, the configuration in yaml would be useless and redundant.
2. alert user if the modules not match backend

## Tests
### Before fix
Nothing happens.
### After fix
for
```yaml
backend: spark_rabbitmq
modules:
  - pulsar
  - rabbitmq
rollsite: 
mysql: 
```
the console will output
`Config Warning: the backend is spark_rabbitmq, so the redundant module pulsar is not supported.`
`Config Warning: the backend is spark_rabbitmq, so whatever configuration you have defined about the redundant rollsite will be ignored.`