### PR TITLE
Support defining resource requirements for rabbitmq, pulsar and nodemanager

### DIFF
--- a/helm-charts/FATE/templates/backends/eggroll/clustermanager/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/clustermanager/deployment.yaml
@@ -37,6 +37,13 @@ spec:
             value: python 
           image: {{ .Values.image.registry }}/eggroll:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.modules.clustermanager.resources}}
+          resources:
+          {{- range $key, $val := .Values.modules.clustermanager.resources }}
+            {{ $key }}:
+{{ toYaml $val | indent 14 }}
+          {{- end }}
+          {{- end }}
           name: clustermanager
           command:
           - bash

--- a/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/deployment.yaml
@@ -54,6 +54,13 @@ spec:
             value: python
           image: {{ .Values.image.registry }}/eggroll:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.modules.lbrollsite.resources}}
+          resources:
+          {{- range $key, $val := .Values.modules.lbrollsite.resources }}
+            {{ $key }}:
+{{ toYaml $val | indent 14 }}
+          {{- end }}
+          {{- end }}
           command:
           - bash
           - -c

--- a/helm-charts/FATE/templates/backends/eggroll/nodemanager/statefulSet.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/nodemanager/statefulSet.yaml
@@ -48,6 +48,13 @@ spec:
             mountPath: /fluentd/etc/fluent.conf
         - image: {{ .Values.image.registry }}/eggroll:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.modules.nodemanager.resources}}
+          resources:
+          {{- range $key, $val := .Values.modules.nodemanager.resources }}
+            {{ $key }}:
+{{ toYaml $val | indent 14 }}
+          {{- end }}
+          {{- end }}
           name: nodemanager
           command:
           - bash

--- a/helm-charts/FATE/templates/backends/eggroll/rollsite/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/rollsite/deployment.yaml
@@ -42,6 +42,13 @@ spec:
             value: python
           image: {{ .Values.image.registry }}/eggroll:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.modules.rollsite.resources}}
+          resources:
+          {{- range $key, $val := .Values.modules.rollsite.resources }}
+            {{ $key }}:
+{{ toYaml $val | indent 14 }}
+          {{- end }}
+          {{- end }}
           command:
           - bash
           - -c

--- a/helm-charts/FATE/templates/backends/spark/pulsar/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/pulsar/deployment.yaml
@@ -35,6 +35,13 @@ spec:
         - name: pulsar
           image: {{ .Values.image.registry }}/pulsar:2.7.0
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.modules.pulsar.resources}}
+          resources:
+          {{- range $key, $val := .Values.modules.pulsar.resources }}
+            {{ $key }}:
+{{ toYaml $val | indent 14 }}
+          {{- end }}
+          {{- end }}
           command:
             - /bin/bash
             - -c

--- a/helm-charts/FATE/templates/backends/spark/rabbitmq/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/rabbitmq/deployment.yaml
@@ -35,6 +35,13 @@ spec:
         - name: rabbitmq
           image: {{ .Values.image.registry }}/rabbitmq:3.8.3-management
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.modules.rabbitmq.resources }}
+          resources:
+          {{- range $key, $val := .Values.modules.rabbitmq.resources }}
+            {{ $key }}:
+{{ toYaml $val | indent 14 }}
+          {{- end }}
+          {{- end }}
           env:
           - name: RABBITMQ_DEFAULT_USER
             value: fate

--- a/helm-charts/FATE/templates/backends/spark/spark/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/spark/deployment.yaml
@@ -123,7 +123,7 @@ spec:
         - name: spark-worker
           image: {{ if .Values.modules.spark.worker.Image }}{{ .Values.modules.spark.worker.Image }}{{ else }}{{ .Values.image.registry }}/spark-worker{{ end }}:{{ default .Values.image.tag .Values.modules.spark.worker.ImageTag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.modules.spark.worker.resresourcesources }}
+          {{- if .Values.modules.spark.worker.resources }}
           resources:
           {{- range $key, $val := .Values.modules.spark.worker.resources }}
             {{ $key }}:

--- a/helm-charts/FATE/templates/backends/spark/spark/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/spark/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: spark-master
           image: {{ if .Values.modules.spark.master.Image }}{{ .Values.modules.spark.master.Image }}{{ else }}{{ .Values.image.registry }}/spark-master{{ end }}:{{ default .Values.image.tag .Values.modules.spark.master.ImageTag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.modules.spark.master.resources}}
+          {{- if .Values.modules.spark.master.resources }}
           resources:
           {{- range $key, $val := .Values.modules.spark.master.resources }}
             {{ $key }}:
@@ -123,7 +123,7 @@ spec:
         - name: spark-worker
           image: {{ if .Values.modules.spark.worker.Image }}{{ .Values.modules.spark.worker.Image }}{{ else }}{{ .Values.image.registry }}/spark-worker{{ end }}:{{ default .Values.image.tag .Values.modules.spark.worker.ImageTag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.modules.spark.worker.resources }}
+          {{- if .Values.modules.spark.worker.resresourcesources }}
           resources:
           {{- range $key, $val := .Values.modules.spark.worker.resources }}
             {{ $key }}:

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -82,6 +82,13 @@ backend: eggroll
     # clientList:
     # - partID: 9999
     # concurrency: 49
+  # resources:
+    # requests:
+      # cpu: "2"
+      # memory: "4Gi"
+    # limits:
+      # cpu: "4"
+      # memory: "8Gi"
 
 
 # lbrollsite:
@@ -96,6 +103,13 @@ backend: eggroll
   # nodeSelector:
   # tolerations:
   # affinity:
+  # resources:
+    # requests:
+      # cpu: "1"
+      # memory: "1Gi"
+    # limits:
+      # cpu: "1"
+      # memory: "1Gi"
 
 # nodemanager:
 #   replicas: 2
@@ -107,6 +121,25 @@ backend: eggroll
 #   storageClass: "local-scsi"
 #   accessMode: ReadWriteOnce
 #   size: 1Gi
+  # resources:
+    # requests:
+      # cpu: "2"
+      # memory: "4Gi"
+    # limits:
+      # cpu: "4"
+      # memory: "8Gi"
+
+# clustermanager:
+#   nodeSelector:
+#   tolerations:
+#   affinity:
+  # resources:
+    # requests:
+      # cpu: "1"
+      # memory: "1Gi"
+    # limits:
+      # cpu: "1"
+      # memory: "1Gi"
 
 
 # python:
@@ -124,6 +157,13 @@ backend: eggroll
   # storageClass: "python"
   # accessMode: ReadWriteMany
   # size: 1Gi
+  # resources:
+    # requests:
+      # cpu: "2"
+      # memory: "4Gi"
+    # limits:
+      # cpu: "4"
+      # memory: "8Gi"
   # clustermanager:
     # cores_per_node: 16
     # nodes: 2
@@ -294,6 +334,13 @@ backend: eggroll
     # 10000:
       # host: 192.168.0.1
       # port: 30104
+  # resources:
+    # requests:
+      # cpu: "2"
+      # memory: "4Gi"
+    # limits:
+      # cpu: "4"
+      # memory: "8Gi"
 
 # pulsar:
   # nodeSelector:
@@ -319,3 +366,10 @@ backend: eggroll
       # port: 30105
       # sslPort: 30109
       # proxy: ""
+  # resources:
+    # requests:
+      # cpu: "2"
+      # memory: "4Gi"
+    # limits:
+      # cpu: "4"
+      # memory: "8Gi"

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -84,11 +84,11 @@ backend: eggroll
     # concurrency: 49
   # resources:
     # requests:
-      # cpu: "2"
-      # memory: "4Gi"
+      # cpu: "1"
+      # memory: "1Gi"
     # limits:
-      # cpu: "4"
-      # memory: "8Gi"
+      # cpu: "41"
+      # memory: "1Gi"
 
 
 # lbrollsite:

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -87,7 +87,7 @@ backend: eggroll
       # cpu: "1"
       # memory: "1Gi"
     # limits:
-      # cpu: "41"
+      # cpu: "4"
       # memory: "1Gi"
 
 

--- a/helm-charts/FATE/values-template.yaml
+++ b/helm-charts/FATE/values-template.yaml
@@ -174,6 +174,10 @@ modules:
       {{- end }}
       concurrency: {{ .concurrency }}
     {{- end }}
+    {{- with .resources }}
+    resources:
+{{ toYaml . | indent 6 }}
+    {{- end }}
     {{- end }}
 
 
@@ -195,6 +199,10 @@ modules:
     {{- end }}
     {{- with .affinity }}
     affinity:
+{{ toYaml . | indent 6 }}
+    {{- end }}
+    {{- with .resources }}
+    resources:
 {{ toYaml . | indent 6 }}
     {{- end }}
     {{- end }}
@@ -287,6 +295,10 @@ modules:
     affinity:
 {{ toYaml . | indent 6 }}
     {{- end }}
+    {{- with .resources }}
+    resources:
+{{ toYaml . | indent 6 }}
+    {{- end }}
     {{- end }}
 
 
@@ -309,6 +321,10 @@ modules:
     {{- end }}
     {{- with .affinity }}
     affinity:
+{{ toYaml . | indent 6 }}
+    {{- end }}
+    {{- with .resources }}
+    resources:
 {{ toYaml . | indent 6 }}
     {{- end }}
     {{- end }}
@@ -515,6 +531,10 @@ modules:
   rabbitmq:
     include: {{ has "rabbitmq" .modules }}
     {{- with .rabbitmq }}
+    {{- with .resources }}
+    resources:
+{{ toYaml . | indent 6 }}
+    {{- end }}
     {{- with .nodeSelector }}
     nodeSelector:
 {{ toYaml . | indent 6 }}
@@ -545,6 +565,10 @@ modules:
   pulsar:
     include: {{ has "pulsar" .modules }}
     {{- with .pulsar }}
+    {{- with .resources }}
+    resources:
+{{ toYaml . | indent 6 }}
+    {{- end }}
     {{- with .nodeSelector }}
     nodeSelector:
 {{ toYaml . | indent 6 }}

--- a/helm-charts/FATE/values.yaml
+++ b/helm-charts/FATE/values.yaml
@@ -85,10 +85,6 @@ modules:
     affinity:
     polling:
       enabled: false
-    resources:
-      requests:
-        cpu: "1"
-        memory: "1Gi"
       
       # type: client
       # server:
@@ -110,10 +106,6 @@ modules:
     nodeSelector:
     tolerations:
     affinity:
-    resources:
-      requests:
-        cpu: "1"
-        memory: "1Gi"
   python: 
     include: true
     type: ClusterIP
@@ -182,10 +174,6 @@ modules:
     nodeSelector:
     tolerations:
     affinity:
-    resources:
-      requests:
-        cpu: "1"
-        memory: "1Gi"
   nodemanager:  
     include: true
     replicas: 2
@@ -197,6 +185,10 @@ modules:
     storageClass: "nodemanager"
     accessMode: ReadWriteOnce
     size: 1Gi
+    resources:
+      requests:
+        cpu: "2"
+        memory: "4Gi"
 
   client: 
     include: true
@@ -261,6 +253,10 @@ modules:
       tolerations:
       affinity:
       type: ClusterIP
+      resources:
+        requests:
+          cpu: "2"
+          memory: "4Gi"
   hdfs:
     include: true
     namenode:

--- a/helm-charts/FATE/values.yaml
+++ b/helm-charts/FATE/values.yaml
@@ -85,6 +85,10 @@ modules:
     affinity:
     polling:
       enabled: false
+    resources:
+      requests:
+        cpu: "1"
+        memory: "1Gi"
       
       # type: client
       # server:
@@ -106,6 +110,10 @@ modules:
     nodeSelector:
     tolerations:
     affinity:
+    resources:
+      requests:
+        cpu: "1"
+        memory: "1Gi"
   python: 
     include: true
     type: ClusterIP
@@ -174,6 +182,10 @@ modules:
     nodeSelector:
     tolerations:
     affinity:
+    resources:
+      requests:
+        cpu: "1"
+        memory: "1Gi"
   nodemanager:  
     include: true
     replicas: 2
@@ -245,13 +257,6 @@ modules:
       Image: ""
       ImageTag: ""
       replicas: 2
-      resources:
-        requests:
-          cpu: "2"
-          memory: "4Gi"
-        limits:
-          cpu: "4"
-          memory: "8Gi"
       nodeSelector:
       tolerations:
       affinity:

--- a/k8s-deploy/README.md
+++ b/k8s-deploy/README.md
@@ -115,6 +115,14 @@ create job success, job id=d92d7a56-7002-46a4-9363-da9c7346e05a
 
 Using KubeFATE to deploy FATE can support four different types, corresponding to four types of backends. They are eggroll, spark_rabbitmq, spark_pulsar and spark_local_pulsar. For more details on the different types of FATE see: [Introduction to FATE Backend Architecture](../docs/Introduction_to_Backend_Architecture.md).
 
+**If you have resource requirements (CPU and memory) for the components, please make sure to check [the example](../helm-charts/FATE/values-template-example.yaml), search for "resources" to know how to define the resource requirements.** 
+
+We support such definition for:
+1. Eggroll components: cluster manager, node manager and rollsite.
+2. Spark components: master and worker.
+3. Rabbitmq.
+4. Pulsar.
+
 ### Checking the status of "Installing Cluster" job
 After the above command has finished, a job is created for installing a FATE cluster. Run the command `kubefate job describe` to check the status of the job, until the "Status" turns to `Success`.
 

--- a/k8s-deploy/README_zh.md
+++ b/k8s-deploy/README_zh.md
@@ -120,6 +120,14 @@ create job success, job id=d92d7a56-7002-46a4-9363-da9c7346e05a
 
 使用KubeFATE部署FATE可以支持四种不同的类型，对应四种backend。分别是eggroll、spark_rabbitmq、spark_pulsar和spark_local_pulsar。关于不同类型的FATE的更多细节查看: [不同类型FATE的架构介绍](../docs/Introduction_to_Backend_Architecture_zh.md)。
 
+**如果某个部件对计算机性能（CPU和内存）有所要求，可以查看[示例文件](../helm-charts/FATE/values-template-example.yaml), 在其中搜索"resources"关键字了解如何进行资源配置.**
+
+我们支持定义如下部件的资源需求:
+1. Eggroll部件：包括cluster manager，node manager和rollsite。
+2. Spark components：包括master和worker。
+3. Rabbitmq。
+4. Pulsar。
+
 ### 检查安装集群任务的状态
 上面的命令会创建一个安装FATE集群的任务，用于异步部署。使用```kubefate job describe```命令可以检查任务的状态，直到看到结果为`install success`
 

--- a/k8s-deploy/cluster-spark-pulsar.yaml
+++ b/k8s-deploy/cluster-spark-pulsar.yaml
@@ -175,3 +175,10 @@ backend: spark_pulsar
       # host: pulsar
       # port: 6650
       # sslPort:6651
+  # resources:
+    # requests:
+      # cpu: "2"
+      # memory: "4Gi"
+    # limits:
+      # cpu: "4"
+      # memory: "8Gi"

--- a/k8s-deploy/cluster-spark-rabbitmq.yaml
+++ b/k8s-deploy/cluster-spark-rabbitmq.yaml
@@ -175,3 +175,10 @@ backend: spark_rabbitmq
       # host: pulsar
       # port: 6650
       # sslPort:6651
+  # resources:
+    # requests:
+      # cpu: "2"
+      # memory: "4Gi"
+    # limits:
+      # cpu: "4"
+      # memory: "8Gi"

--- a/k8s-deploy/cluster-spark-slim.yaml
+++ b/k8s-deploy/cluster-spark-slim.yaml
@@ -173,3 +173,10 @@ backend: spark_local_pulsar
       # host: pulsar
       # port: 6650
       # sslPort:6651
+  # resources:
+    # requests:
+      # cpu: "2"
+      # memory: "4Gi"
+    # limits:
+      # cpu: "4"
+      # memory: "8Gi"

--- a/k8s-deploy/cluster.yaml
+++ b/k8s-deploy/cluster.yaml
@@ -56,7 +56,27 @@ backend: eggroll
   # - partyId: 10000
     # partyIp: 192.168.0.1
     # partyPort: 30101
-  # nodeSelector: 
+  # nodeSelector:
+  # resources:
+    # requests:
+      # cpu: "1"
+      # memory: "1Gi"
+    # limits:
+      # cpu: "1"
+      # memory: "1Gi"
+
+# Specify clustermanager properties
+# clustermanager:
+#   nodeSelector:
+#   tolerations:
+#   affinity:
+  # resources:
+    # requests:
+      # cpu: "1"
+      # memory: "1Gi"
+    # limits:
+      # cpu: "1"
+      # memory: "1Gi"
 
 # Specify nodemanager properties
 # nodemanager:
@@ -69,6 +89,13 @@ backend: eggroll
 #   storageClass: "local-scsi"
 #   accessMode: ReadWriteOnce
 #   size: 1Gi
+  # resources:
+    # requests:
+      # cpu: "2"
+      # memory: "4Gi"
+    # limits:
+      # cpu: "4"
+      # memory: "8Gi"
 
 # Specify the fateflow service's properties
 # python:


### PR DESCRIPTION
Fixes #668 

## Changes

1. Support defining resource requirements for rabbitmq, pulsar and nodemanager.

2. Update the doc to hint the user to configure the resource limit and requirement.

3. Remove the default resource config of spark worker.

I think there is no need to set anything for spark master, eggroll rollsite and cluster manager because they will not consume many resources. We just make the resources eaters configurable.

## Test:
Have tried to add the configuration in pulsar, rabbitmq, spark worker and eggroll nodemanager.

All of them succeed.