### PR TITLE
remove warning on chartVersion

### DIFF
--- a/k8s-deploy/pkg/cli/cluster_cli.go
+++ b/k8s-deploy/pkg/cli/cluster_cli.go
@@ -164,7 +164,10 @@ func ClusterInstallCommand() *cli.Command {
 			}
 
 			if template, err := GetValueTemplateExample(chartName.(string), chartVersion.(string)); err != nil {
-				color.Yellow("Config Warning: %s\n", err.Error())
+				if _, ok := err.(VersionNotValidError); !ok {
+					// if the error is not VersionNotValidError, warn user.
+					color.Yellow("Config Warning: %s\n", err.Error())
+				}
 			} else {
 				skippedKeys := getSkippedKeys(m)
 				errs := ValidateYaml(template, string(clusterConfig), skippedKeys)

--- a/k8s-deploy/pkg/cli/validation.go
+++ b/k8s-deploy/pkg/cli/validation.go
@@ -38,6 +38,15 @@ type ValidationManager struct {
 	skippedKeys            []string
 }
 
+type VersionNotValidError struct {
+	Version    string
+	LowerBound string
+}
+
+func (e VersionNotValidError) Error() string {
+	return fmt.Sprintf("version of %s does not meet the validation requirement that chartVersion >= %s", e.Version, e.LowerBound)
+}
+
 // // trimComments trims the comments started with "# ".
 func trimComments(t []byte) []byte {
 	pattern := regexp.MustCompile(`^ *# `)
@@ -203,7 +212,7 @@ func versionValid(chartVersion string, startVersion []int) (valid bool) {
 // GetValueTemplateExample gets the value template example from api.
 func GetValueTemplateExample(chartName, chartVersion string) (value string, err error) {
 	if !versionValid(chartVersion, []int{1, 9, 0}) {
-		err = errors.New("yaml validation requires the chartVersion >= 1.9.0")
+		err = VersionNotValidError{chartVersion, "1.9.0"}
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: hang lv <xlv20@fudan.edu.cn>

Fixes  ISSUE#517

Changes:

1. if the chartVersion <1.9.0, just skip the validation instead of warning user the validation requirement on chartVersion


