### PR TITLE
Fix a typo everywhere in the helm chart templates

### DIFF
--- a/helm-charts/FATE-Exchange/templates/nginx.yaml
+++ b/helm-charts/FATE-Exchange/templates/nginx.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: nginx-config
   labels:
-    fateMoudle: nginx
+    fateModule: nginx
 {{ include "fate.labels" . | indent 4 }}
 data:
   route_table.yaml: |
@@ -113,7 +113,7 @@ kind: Deployment
 metadata:
   name: nginx
   labels:
-    fateMoudle: nginx
+    fateModule: nginx
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: {{ default 1 .Values.modules.nginx.replicas }}
@@ -121,12 +121,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: nginx
+      fateModule: nginx
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: nginx
+        fateModule: nginx
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:
@@ -177,7 +177,7 @@ kind: Service
 metadata:
   name: nginx
   labels:
-    fateMoudle: nginx
+    fateModule: nginx
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -200,7 +200,7 @@ spec:
   loadBalancerIP: "{{ .Values.modules.nginx.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateMoudle: nginx
+    fateModule: nginx
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{ end }}

--- a/helm-charts/FATE-Exchange/templates/psp.yaml
+++ b/helm-charts/FATE-Exchange/templates/psp.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:
-    fateMoudle: psp
+    fateModule: psp
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 spec:

--- a/helm-charts/FATE-Exchange/templates/role.yaml
+++ b/helm-charts/FATE-Exchange/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    fateMoudle: role
+    fateModule: role
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 rules:

--- a/helm-charts/FATE-Exchange/templates/rolebinding.yaml
+++ b/helm-charts/FATE-Exchange/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    fateMoudle: serviceAccount
+    fateModule: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 roleRef:

--- a/helm-charts/FATE-Exchange/templates/rollsite-module.yaml
+++ b/helm-charts/FATE-Exchange/templates/rollsite-module.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: rollsite-config
   labels:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.labels" . | indent 4 }}
 data:
   eggroll.properties: |
@@ -85,7 +85,7 @@ kind: Deployment
 metadata:
   name: rollsite
   labels:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -93,12 +93,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: rollsite
+      fateModule: rollsite
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: rollsite
+        fateModule: rollsite
 {{ include "fate.labels" . | indent 8 }}
     spec:
       hostAliases:
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: rollsite
   labels:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -177,7 +177,7 @@ spec:
   loadBalancerIP: "{{ .Values.modules.rollsite.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{ end }}

--- a/helm-charts/FATE-Exchange/templates/serviceaccount.yaml
+++ b/helm-charts/FATE-Exchange/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    fateMoudle: serviceAccount
+    fateModule: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 {{- end -}}

--- a/helm-charts/FATE-Exchange/templates/traffic-server-module.yaml
+++ b/helm-charts/FATE-Exchange/templates/traffic-server-module.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: traffic-server-config
   labels:
-    fateMoudle: traffic-server
+    fateModule: traffic-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote }}
     owner: kubefate
@@ -46,7 +46,7 @@ apiVersion: v1
 metadata:
   name: traffic-server-sni
   labels:
-    fateMoudle: traffic-server
+    fateModule: traffic-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote }}
     owner: kubefate
@@ -64,7 +64,7 @@ kind: Deployment
 metadata:
   name: traffic-server
   labels:
-    fateMoudle: traffic-server
+    fateModule: traffic-server
     name: {{ .Values.partyName  | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -75,13 +75,13 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: traffic-server
+      fateModule: traffic-server
       name: {{ .Values.partyName  | quote }}
       partyId: {{ .Values.partyId | quote  }}
   template:
     metadata:
       labels:
-        fateMoudle: traffic-server
+        fateModule: traffic-server
         name: {{ .Values.partyName | quote  }}
         partyId: {{ .Values.partyId | quote  }}
         owner: kubefate
@@ -148,7 +148,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    fateMoudle: traffic-server
+    fateModule: traffic-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote }}
     owner: kubefate
@@ -166,7 +166,7 @@ spec:
   loadBalancerIP: "{{ .Values.modules.trafficServer.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateMoudle: traffic-server
+    fateModule: traffic-server
     name: {{ .Values.partyName | quote }}
     partyId: {{ .Values.partyId | quote  }}
 ---

--- a/helm-charts/FATE-Serving/templates/ingress.yaml
+++ b/helm-charts/FATE-Serving/templates/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: serving-proxy
   labels:
-    fateMoudle: serving-proxy
+    fateModule: serving-proxy
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -52,7 +52,7 @@ kind: Ingress
 metadata:
   name: serving-admin
   labels:
-    fateMoudle: serving-admin
+    fateModule: serving-admin
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate

--- a/helm-charts/FATE-Serving/templates/istio.yaml
+++ b/helm-charts/FATE-Serving/templates/istio.yaml
@@ -31,7 +31,7 @@ kind: VirtualService
 metadata:
   name: fate-serving-ingress
   labels:
-      fateMoudle: serving-proxy
+      fateModule: serving-proxy
       name: {{ .Values.partyName | quote  }}
       partyId: {{ .Values.partyId | quote  }}
       owner: kubefate

--- a/helm-charts/FATE-Serving/templates/psp.yaml
+++ b/helm-charts/FATE-Serving/templates/psp.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:
-    fateMoudle: psp
+    fateModule: psp
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 spec:

--- a/helm-charts/FATE-Serving/templates/role.yaml
+++ b/helm-charts/FATE-Serving/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    fateMoudle: role
+    fateModule: role
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 rules:

--- a/helm-charts/FATE-Serving/templates/rolebinding.yaml
+++ b/helm-charts/FATE-Serving/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    fateMoudle: serviceAccount
+    fateModule: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 roleRef:

--- a/helm-charts/FATE-Serving/templates/serviceaccount.yaml
+++ b/helm-charts/FATE-Serving/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    fateMoudle: serviceAccount
+    fateModule: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 {{- end -}}

--- a/helm-charts/FATE-Serving/templates/serving-admin-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-admin-module.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: serving-admin-config
   labels:
-    fateMoudle: serving-admin
+    fateModule: serving-admin
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -44,7 +44,7 @@ kind: Deployment
 metadata:
   name: serving-admin
   labels:
-    fateMoudle: serving-admin
+    fateModule: serving-admin
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -55,13 +55,13 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: serving-admin
+      fateModule: serving-admin
       name: {{ .Values.partyName | quote  }}
       partyId: {{ .Values.partyId | quote  }}
   template:
     metadata:
       labels:
-        fateMoudle: serving-admin
+        fateModule: serving-admin
         name: {{ .Values.partyName | quote  }}
         partyId: {{ .Values.partyId | quote  }}
         owner: kubefate
@@ -104,7 +104,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    fateMoudle: serving-admin
+    fateModule: serving-admin
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -121,7 +121,7 @@ spec:
       protocol: TCP
   type: {{ .Values.servingAdmin.type }}
   selector:
-    fateMoudle: serving-admin
+    fateModule: serving-admin
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
 {{ end }}

--- a/helm-charts/FATE-Serving/templates/serving-proxy-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-proxy-module.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: serving-proxy-config
   labels:
-    fateMoudle: serving-proxy
+    fateModule: serving-proxy
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote }}
     owner: kubefate
@@ -133,7 +133,7 @@ kind: Deployment
 metadata:
   name: serving-proxy
   labels:
-    fateMoudle: serving-proxy
+    fateModule: serving-proxy
     name: {{ .Values.partyName  | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -144,13 +144,13 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: serving-proxy
+      fateModule: serving-proxy
       name: {{ .Values.partyName  | quote }}
       partyId: {{ .Values.partyId | quote  }}
   template:
     metadata:
       labels:
-        fateMoudle: serving-proxy
+        fateModule: serving-proxy
         name: {{ .Values.partyName | quote  }}
         partyId: {{ .Values.partyId | quote  }}
         owner: kubefate
@@ -206,7 +206,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    fateMoudle: serving-proxy
+    fateModule: serving-proxy
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote }}
     owner: kubefate
@@ -232,7 +232,7 @@ spec:
   loadBalancerIP: "{{ .Values.servingProxy.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateMoudle: serving-proxy
+    fateModule: serving-proxy
     name: {{ .Values.partyName | quote }}
     partyId: {{ .Values.partyId | quote  }}
 ---

--- a/helm-charts/FATE-Serving/templates/serving-redis-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-redis-module.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: serving-redis-config
   labels:
-    fateMoudle: serving-redis
+    fateModule: serving-redis
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId  | quote }}
     owner: kubefate
@@ -31,7 +31,7 @@ kind: Deployment
 metadata:
   name: serving-redis
   labels:
-    fateMoudle: serving-redis
+    fateModule: serving-redis
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -42,13 +42,13 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: serving-redis
+      fateModule: serving-redis
       name: {{ .Values.partyName | quote  }}
       partyId: {{ .Values.partyId | quote  }}
   template:
     metadata:
       labels:
-        fateMoudle: serving-redis
+        fateModule: serving-redis
         name: {{ .Values.partyName | quote  }}
         partyId: {{ .Values.partyId | quote  }}
         owner: kubefate
@@ -114,7 +114,7 @@ kind: Service
 metadata:
   name: serving-redis
   labels:
-    fateMoudle: serving-redis
+    fateModule: serving-redis
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -126,7 +126,7 @@ spec:
       targetPort: 6379
       protocol: TCP
   selector:
-    fateMoudle: serving-redis
+    fateModule: serving-redis
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
 ---
@@ -136,7 +136,7 @@ apiVersion: v1
 metadata:
   name: serving-redis-data
   labels:
-    fateMoudle: serving-redis
+    fateModule: serving-redis
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate

--- a/helm-charts/FATE-Serving/templates/serving-server-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-server-module.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: serving-server-config
   labels:
-    fateMoudle: serving-server
+    fateModule: serving-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -73,7 +73,7 @@ kind: Deployment
 metadata:
   name: serving-server
   labels:
-    fateMoudle: serving-server
+    fateModule: serving-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -84,13 +84,13 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: serving-server
+      fateModule: serving-server
       name: {{ .Values.partyName | quote  }}
       partyId: {{ .Values.partyId | quote  }}
   template:
     metadata:
       labels:
-        fateMoudle: serving-server
+        fateModule: serving-server
         name: {{ .Values.partyName | quote  }}
         partyId: {{ .Values.partyId | quote  }}
         owner: kubefate
@@ -145,7 +145,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    fateMoudle: serving-server
+    fateModule: serving-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -165,7 +165,7 @@ spec:
   loadBalancerIP: "{{ .Values.servingServer.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateMoudle: serving-server
+    fateModule: serving-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
 ---
@@ -175,7 +175,7 @@ apiVersion: v1
 metadata:
   name: serving-server-data
   labels:
-    fateMoudle: serving-server
+    fateModule: serving-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate

--- a/helm-charts/FATE-Serving/templates/serving-zookeeper-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-zookeeper-module.yaml
@@ -16,7 +16,7 @@ kind: Service
 metadata:
   name: serving-zookeeper
   labels:
-    fateMoudle: serving-zookeeper
+    fateModule: serving-zookeeper
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -34,7 +34,7 @@ spec:
       port: 3888
       targetPort: election
   selector:
-    fateMoudle: serving-zookeeper
+    fateModule: serving-zookeeper
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
 ---
@@ -44,7 +44,7 @@ kind: StatefulSet
 metadata:
   name: serving-zookeeper
   labels:
-    fateMoudle: serving-zookeeper
+    fateModule: serving-zookeeper
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -57,14 +57,14 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      fateMoudle: serving-zookeeper
+      fateModule: serving-zookeeper
       name: {{ .Values.partyName | quote }}
       partyId: {{ .Values.partyId | quote }}
   template:
     metadata:
       name: serving-zookeeper
       labels:
-        fateMoudle: serving-zookeeper
+        fateModule: serving-zookeeper
         name: {{ .Values.partyName | quote }}
         partyId: {{ .Values.partyId | quote }}
         owner: kubefate
@@ -205,7 +205,7 @@ spec:
     - metadata:
         name: data
         labels:
-          fateMoudle: serving-zookeeper
+          fateModule: serving-zookeeper
           name: {{ .Values.partyName | quote }}
           partyId: {{ .Values.partyId | quote }}
           owner: kubefate

--- a/helm-charts/FATE/templates/backends/eggroll/clustermanager/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/clustermanager/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: clustermanager
   labels:
-    fateMoudle: clustermanager
+    fateModule: clustermanager
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: clustermanager
+      fateModule: clustermanager
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: clustermanager
+        fateModule: clustermanager
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:

--- a/helm-charts/FATE/templates/backends/eggroll/clustermanager/service.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/clustermanager/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: clustermanager
   labels:
-    fateMoudle: clustermanager
+    fateModule: clustermanager
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -26,6 +26,6 @@ spec:
   type: {{ .Values.modules.clustermanager.type }}
   clusterIP: None
   selector:
-    fateMoudle: clustermanager
+    fateModule: clustermanager
 {{ include "fate.matchLabels" . | indent 4 }}
 {{ end }}

--- a/helm-charts/FATE/templates/backends/eggroll/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: eggroll-config
   labels:
-    fateMoudle: eggroll
+    fateModule: eggroll
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate

--- a/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: rollsite-config
   labels:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.labels" . | indent 4 }}
 data:
   route_table.json: |

--- a/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: rollsite
   labels:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: rollsite
+      fateModule: rollsite
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: rollsite
+        fateModule: rollsite
 {{ include "fate.labels" . | indent 8 }}
     spec:
       hostAliases:

--- a/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/service.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: rollsite
   labels:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -31,7 +31,7 @@ spec:
   loadBalancerIP: "{{ .Values.modules.lbrollsite.loadBalancerIP }}"
 {{- end }}
   selector:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 apiVersion: v1
@@ -39,7 +39,7 @@ kind: Service
 metadata:
   name: exchange
   labels:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -52,7 +52,7 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.lbrollsite.type }}
   selector:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{ end }}

--- a/helm-charts/FATE/templates/backends/eggroll/nodemanager/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/nodemanager/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: fluentd-config
   labels:
-    fateMoudle: nodemanager
+    fateModule: nodemanager
 {{ include "fate.labels" . | indent 4 }}
 data:
   fluent.conf: |

--- a/helm-charts/FATE/templates/backends/eggroll/nodemanager/service.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/nodemanager/service.yaml
@@ -14,7 +14,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    fateMoudle: nodemanager
+    fateModule: nodemanager
 {{ include "fate.labels" . | indent 4 }}
   name: nodemanager
 spec:
@@ -25,6 +25,6 @@ spec:
       protocol: TCP
   clusterIP: None
   selector:
-    fateMoudle: nodemanager
+    fateModule: nodemanager
 {{ include "fate.matchLabels" . | indent 4 }}
 {{- end }}

--- a/helm-charts/FATE/templates/backends/eggroll/nodemanager/statefulSet.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/nodemanager/statefulSet.yaml
@@ -16,7 +16,7 @@ kind: StatefulSet
 metadata:
   name: nodemanager
   labels:
-    fateMoudle: nodemanager
+    fateModule: nodemanager
     app: nodemanager
 {{ include "fate.labels" . | indent 4 }}
 spec:
@@ -24,12 +24,12 @@ spec:
   serviceName: nodemanager
   selector:
     matchLabels:
-      fateMoudle: nodemanager
+      fateModule: nodemanager
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: nodemanager
+        fateModule: nodemanager
         app: nodemanager
 {{ include "fate.labels" . | indent 8 }}
     spec:

--- a/helm-charts/FATE/templates/backends/eggroll/rollsite/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/rollsite/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: rollsite-config
   labels:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.labels" . | indent 4 }}
 data:
   route_table.json: |

--- a/helm-charts/FATE/templates/backends/eggroll/rollsite/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/rollsite/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: rollsite
   labels:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: rollsite
+      fateModule: rollsite
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: rollsite
+        fateModule: rollsite
 {{ include "fate.labels" . | indent 8 }}
     spec:
       hostAliases:

--- a/helm-charts/FATE/templates/backends/eggroll/rollsite/service.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/rollsite/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: rollsite
   labels:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -31,6 +31,6 @@ spec:
   loadBalancerIP: "{{ .Values.modules.rollsite.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateMoudle: rollsite
+    fateModule: rollsite
 {{ include "fate.matchLabels" . | indent 4 }}
 {{ end }}

--- a/helm-charts/FATE/templates/backends/spark/hdfs/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: namenode-config
   labels:
-    fateMoudle: namenode
+    fateModule: namenode
 {{ include "fate.labels" . | indent 4 }}
 data:
   core-site.xml: |
@@ -31,7 +31,7 @@ apiVersion: v1
 metadata:
   name: namenode-env
   labels:
-    fateMoudle: namenode
+    fateModule: namenode
 {{ include "fate.labels" . | indent 4 }}
 data:
   MULTIHOMED_NETWORK: "0"
@@ -87,7 +87,7 @@ apiVersion: v1
 metadata:
   name: datanode-env
   labels:
-    fateMoudle: datanode
+    fateModule: datanode
 {{ include "fate.labels" . | indent 4 }}
 data:
   MULTIHOMED_NETWORK: "0"

--- a/helm-charts/FATE/templates/backends/spark/hdfs/datanode.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/datanode.yaml
@@ -15,19 +15,19 @@ kind: StatefulSet
 metadata:
   name: datanode
   labels:
-    fateMoudle: datanode
+    fateModule: datanode
 {{ include "fate.labels" . | indent 4 }}
 spec:
   serviceName: datanode
   replicas: {{ .Values.modules.hdfs.datanode.replicas }}
   selector:
     matchLabels:
-      fateMoudle: datanode
+      fateModule: datanode
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: datanode
+        fateModule: datanode
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:
@@ -109,7 +109,7 @@ spec:
     - metadata:
         name: dfs
         labels:
-          fateMoudle: datanode
+          fateModule: datanode
 {{ include "fate.labels" . | indent 10 }}
       spec:
         accessModes: [{{ .Values.modules.hdfs.datanode.accessMode }}]

--- a/helm-charts/FATE/templates/backends/spark/hdfs/namenode.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/namenode.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: namenode
   labels:
-    fateMoudle: namenode
+    fateModule: namenode
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: namenode
+      fateModule: namenode
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: namenode
+        fateModule: namenode
 {{ include "fate.labels" . | indent 8 }}
     spec:
     {{ if .Values.persistence.enabled }}

--- a/helm-charts/FATE/templates/backends/spark/hdfs/persistentvolumeclaim.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/persistentvolumeclaim.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 metadata:
   name: namenode-data
   labels:
-    fateMoudle: namenode
+    fateModule: namenode
 {{ include "fate.labels" . | indent 4 }}
 spec:
   accessModes:

--- a/helm-charts/FATE/templates/backends/spark/hdfs/service.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: datanode
   labels:
-    fateMoudle: datanode
+    fateModule: datanode
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -33,7 +33,7 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.hdfs.datanode.type }}
   selector:
-    fateMoudle: datanode
+    fateModule: datanode
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 apiVersion: v1
@@ -41,7 +41,7 @@ kind: Service
 metadata:
   name: namenode
   labels:
-    fateMoudle: namenode
+    fateModule: namenode
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -62,7 +62,7 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.hdfs.namenode.type }}
   selector:
-    fateMoudle: namenode
+    fateModule: namenode
 {{ include "fate.matchLabels" . | indent 4 }}
 
 {{ end }}

--- a/helm-charts/FATE/templates/backends/spark/nginx/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/spark/nginx/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: nginx-config
   labels:
-    fateMoudle: nginx
+    fateModule: nginx
 {{ include "fate.labels" . | indent 4 }}
 data:
   route_table.yaml: |

--- a/helm-charts/FATE/templates/backends/spark/nginx/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/nginx/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: nginx
   labels:
-    fateMoudle: nginx
+    fateModule: nginx
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: nginx
+      fateModule: nginx
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: nginx
+        fateModule: nginx
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:

--- a/helm-charts/FATE/templates/backends/spark/nginx/service.yaml
+++ b/helm-charts/FATE/templates/backends/spark/nginx/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: nginx
   labels:
-    fateMoudle: nginx
+    fateModule: nginx
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -40,6 +40,6 @@ spec:
   {{- end }}
   
   selector:
-    fateMoudle: nginx
+    fateModule: nginx
 {{ include "fate.matchLabels" . | indent 4 }}
 {{ end }}

--- a/helm-charts/FATE/templates/backends/spark/pulsar/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/spark/pulsar/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: pulsar-config
   labels:
-    fateMoudle: pulsar
+    fateModule: pulsar
 {{ include "fate.labels" . | indent 4 }}
 data:
   standalone.conf: |

--- a/helm-charts/FATE/templates/backends/spark/pulsar/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/pulsar/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: pulsar
   labels:
-    fateMoudle: pulsar
+    fateModule: pulsar
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: pulsar
+      fateModule: pulsar
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: pulsar
+        fateModule: pulsar
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:

--- a/helm-charts/FATE/templates/backends/spark/pulsar/ingress.yaml
+++ b/helm-charts/FATE/templates/backends/spark/pulsar/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: pulsar
   labels:
-    fateMoudle: pulsar
+    fateModule: pulsar
 {{ include "fate.labels" . | indent 4 }}
 {{- if .Values.ingress.pulsar.annotations }}
   annotations:

--- a/helm-charts/FATE/templates/backends/spark/pulsar/persistentvolumeclaim.yaml
+++ b/helm-charts/FATE/templates/backends/spark/pulsar/persistentvolumeclaim.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 metadata:
   name: pulsar-data
   labels:
-    fateMoudle: pulsar
+    fateModule: pulsar
 {{ include "fate.labels" . | indent 4 }}
 spec:
   accessModes:

--- a/helm-charts/FATE/templates/backends/spark/pulsar/service.yaml
+++ b/helm-charts/FATE/templates/backends/spark/pulsar/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: pulsar
   labels:
-    fateMoudle: pulsar
+    fateModule: pulsar
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -48,7 +48,7 @@ spec:
   {{- end }}
   
   selector:
-    fateMoudle: pulsar
+    fateModule: pulsar
 {{ include "fate.matchLabels" . | indent 4 }}
 
 ---
@@ -59,7 +59,7 @@ kind: Service
 metadata:
   name: pulsar-public-tls
   labels:
-    fateMoudle: pulsar
+    fateModule: pulsar
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -69,7 +69,7 @@ spec:
     protocol: TCP
   type: LoadBalancer
   selector:
-    fateMoudle: pulsar
+    fateModule: pulsar
 {{ include "fate.matchLabels" . | indent 4 }}
 {{- end }}
 

--- a/helm-charts/FATE/templates/backends/spark/rabbitmq/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/spark/rabbitmq/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: rabbitmq-config
   labels:
-    fateMoudle: rabbitmq
+    fateModule: rabbitmq
 {{ include "fate.labels" . | indent 4 }}
 data:
   enabled_plugins: |

--- a/helm-charts/FATE/templates/backends/spark/rabbitmq/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/rabbitmq/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: rabbitmq
   labels:
-    fateMoudle: rabbitmq
+    fateModule: rabbitmq
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: rabbitmq
+      fateModule: rabbitmq
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: rabbitmq
+        fateModule: rabbitmq
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:

--- a/helm-charts/FATE/templates/backends/spark/rabbitmq/ingress.yaml
+++ b/helm-charts/FATE/templates/backends/spark/rabbitmq/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: rabbitmq
   labels:
-    fateMoudle: rabbitmq
+    fateModule: rabbitmq
 {{ include "fate.labels" . | indent 4 }}
 {{- if .Values.ingress.rabbitmq.annotations }}
   annotations:

--- a/helm-charts/FATE/templates/backends/spark/rabbitmq/service.yaml
+++ b/helm-charts/FATE/templates/backends/spark/rabbitmq/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: rabbitmq
   labels:
-    fateMoudle: rabbitmq
+    fateModule: rabbitmq
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -35,7 +35,7 @@ spec:
   loadBalancerIP: "{{ .Values.modules.rabbitmq.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateMoudle: rabbitmq
+    fateModule: rabbitmq
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{ end }}

--- a/helm-charts/FATE/templates/backends/spark/spark/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/spark/spark/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: spark-worker-config
   labels:
-    fateMoudle: spark-worker
+    fateModule: spark-worker
 {{ include "fate.labels" . | indent 4 }}
 data:
   service_conf.yaml: |

--- a/helm-charts/FATE/templates/backends/spark/spark/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/spark/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: spark-master
   labels:
-    fateMoudle: spark-master
+    fateModule: spark-master
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: {{ default 1 .Values.modules.spark.master.replicas }}
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: spark-master
+      fateModule: spark-master
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: spark-master
+        fateModule: spark-master
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:
@@ -103,7 +103,7 @@ kind: Deployment
 metadata:
   name: spark-worker
   labels:
-    fateMoudle: spark-worker
+    fateModule: spark-worker
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: {{ default 2 .Values.modules.spark.worker.replicas }}
@@ -111,12 +111,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: spark-worker
+      fateModule: spark-worker
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: spark-worker
+        fateModule: spark-worker
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:

--- a/helm-charts/FATE/templates/backends/spark/spark/ingress.yaml
+++ b/helm-charts/FATE/templates/backends/spark/spark/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: spark
   labels:
-    fateMoudle: spark
+    fateModule: spark
 {{ include "fate.labels" . | indent 4 }}
 {{- if .Values.ingress.spark.annotations }}
   annotations:

--- a/helm-charts/FATE/templates/backends/spark/spark/service.yaml
+++ b/helm-charts/FATE/templates/backends/spark/spark/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: spark-master
   labels:
-    fateMoudle: spark-master
+    fateModule: spark-master
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -34,7 +34,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   selector:
-    fateMoudle: spark-master
+    fateModule: spark-master
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 apiVersion: v1
@@ -42,7 +42,7 @@ kind: Service
 metadata:
   name: spark-client
   labels:
-    fateMoudle: spark-master
+    fateModule: spark-master
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -64,7 +64,7 @@ spec:
   type: {{ .Values.modules.spark.master.type }}
   # clusterIP: None
   selector:
-    fateMoudle: spark-master
+    fateModule: spark-master
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 apiVersion: v1
@@ -72,7 +72,7 @@ kind: Service
 metadata:
   name: spark-worker-1
   labels:
-    fateMoudle: spark-worker
+    fateModule: spark-worker
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -83,7 +83,7 @@ spec:
   type: {{ .Values.modules.spark.worker.type }}
   clusterIP: None
   selector:
-    fateMoudle: spark-worker
+    fateModule: spark-worker
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{ end }}

--- a/helm-charts/FATE/templates/core/client/deployment.yaml
+++ b/helm-charts/FATE/templates/core/client/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: client
   labels:
-    fateMoudle: client
+    fateModule: client
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: client
+      fateModule: client
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: client
+        fateModule: client
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:

--- a/helm-charts/FATE/templates/core/client/ingress.yaml
+++ b/helm-charts/FATE/templates/core/client/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: client
   labels:
-    fateMoudle: client
+    fateModule: client
 {{ include "fate.labels" . | indent 4 }}
   {{- if .Values.ingress.client.annotations }}
   annotations:

--- a/helm-charts/FATE/templates/core/client/persistentvolumeclaim.yaml
+++ b/helm-charts/FATE/templates/core/client/persistentvolumeclaim.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 metadata:
   name: client-data
   labels:
-    fateMoudle: client
+    fateModule: client
 {{ include "fate.labels" . | indent 4 }}
 spec:
   accessModes: 

--- a/helm-charts/FATE/templates/core/client/service.yaml
+++ b/helm-charts/FATE/templates/core/client/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: notebook
   labels:
-    fateMoudle: client
+    fateModule: client
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -25,6 +25,6 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.client.type }}
   selector:
-    fateMoudle: client
+    fateModule: client
 {{ include "fate.matchLabels" . | indent 4 }}
 {{- end }}

--- a/helm-charts/FATE/templates/core/fateboard/configmap.yaml
+++ b/helm-charts/FATE/templates/core/fateboard/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: fateboard-config
   labels:
-    fateMoudle: fateboard
+    fateModule: fateboard
 {{ include "fate.labels" . | indent 4 }}
 data:
   application.properties: |

--- a/helm-charts/FATE/templates/core/fateboard/ingress.yaml
+++ b/helm-charts/FATE/templates/core/fateboard/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: fateboard
   labels:
-    fateMoudle: fateboard
+    fateModule: fateboard
 {{ include "fate.labels" . | indent 4 }}
 {{- if .Values.ingress.fateboard.annotations }}
   annotations:

--- a/helm-charts/FATE/templates/core/fateboard/service.yaml
+++ b/helm-charts/FATE/templates/core/fateboard/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: fateboard
   labels:
-    fateMoudle: python
+    fateModule: python
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -25,6 +25,6 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.fateboard.type }}
   selector:
-    fateMoudle: python
+    fateModule: python
 {{ include "fate.matchLabels" . | indent 4 }}
 {{- end }}

--- a/helm-charts/FATE/templates/core/fateflow/configmap.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: python-config
   labels:
-    fateMoudle: python
+    fateModule: python
 {{ include "fate.labels" . | indent 4 }}
 data:
   spark-defaults.conf: |
@@ -255,7 +255,7 @@ apiVersion: v1
 metadata:
   name: pulsar-route-table
   labels:
-    fateMoudle: python
+    fateModule: python
 {{ include "fate.labels" . | indent 4 }}
 data:
   pulsar_route_table.yaml: |
@@ -282,7 +282,7 @@ apiVersion: v1
 metadata:
   name: rabbitmq-route-table
   labels:
-    fateMoudle: python
+    fateModule: python
 {{ include "fate.labels" . | indent 4 }}
 data:
   rabbitmq_route_table.yaml: |

--- a/helm-charts/FATE/templates/core/fateflow/persistentvolumeclaim.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/persistentvolumeclaim.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 metadata:
   name: python-data
   labels:
-    fateMoudle: python
+    fateModule: python
 {{ include "fate.labels" . | indent 4 }}
 spec:
   accessModes: 

--- a/helm-charts/FATE/templates/core/fateflow/service.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: fateflow
   labels:
-    fateMoudle: fateflow
+    fateModule: fateflow
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -30,7 +30,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   selector:
-    fateMoudle: python
+    fateModule: python
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 apiVersion: v1
@@ -38,7 +38,7 @@ kind: Service
 metadata:
   name: fateflow-client
   labels:
-    fateMoudle: fateflow
+    fateModule: fateflow
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -63,7 +63,7 @@ spec:
   {{- end }}
   
   selector:
-    fateMoudle: python
+    fateModule: python
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{- if and .Values.modules.python.spark.portMaxRetries (ne (print .Values.modules.python.spark.driverHost) "fateflow") }}
@@ -72,7 +72,7 @@ kind: Service
 metadata:
   name: fateflow-sparkdriver
   labels:
-    fateMoudle: python
+    fateModule: python
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -95,7 +95,7 @@ spec:
     {{- end }}
   type: {{ .Values.modules.python.spark.driverHostType }}
   selector:
-    fateMoudle: python
+    fateModule: python
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{- end }}

--- a/helm-charts/FATE/templates/core/mysql/configmap.yaml
+++ b/helm-charts/FATE/templates/core/mysql/configmap.yaml
@@ -15,7 +15,7 @@ kind: ConfigMap
 metadata:
   name: mysql-config
   labels:
-    fateMoudle: mysql
+    fateModule: mysql
 {{ include "fate.labels" . | indent 4 }}
 data:
   {{- if eq .Values.modules.python.backend  "spark" }}

--- a/helm-charts/FATE/templates/core/mysql/deployment.yaml
+++ b/helm-charts/FATE/templates/core/mysql/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: mysql
   labels:
-    fateMoudle: mysql
+    fateModule: mysql
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: mysql
+      fateModule: mysql
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: mysql
+        fateModule: mysql
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:

--- a/helm-charts/FATE/templates/core/mysql/persistentvolumeclaim.yaml
+++ b/helm-charts/FATE/templates/core/mysql/persistentvolumeclaim.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 metadata:
   name: mysql-data
   labels:
-    fateMoudle: mysql
+    fateModule: mysql
 {{ include "fate.labels" . | indent 4 }}
 spec:
   accessModes: 

--- a/helm-charts/FATE/templates/core/mysql/service.yaml
+++ b/helm-charts/FATE/templates/core/mysql/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: mysql
   labels:
-    fateMoudle: mysql
+    fateModule: mysql
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -25,6 +25,6 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.mysql.type }}
   selector:
-    fateMoudle: mysql
+    fateModule: mysql
 {{ include "fate.matchLabels" . | indent 4 }}
 {{ end }}

--- a/helm-charts/FATE/templates/core/python-spark.yaml
+++ b/helm-charts/FATE/templates/core/python-spark.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: python
   labels:
-    fateMoudle: python
+    fateModule: python
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateMoudle: python
+      fateModule: python
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateMoudle: python
+        fateModule: python
 {{ include "fate.labels" . | indent 8 }}
     spec:
       {{- if .Values.istio.enabled }}

--- a/helm-charts/FATE/templates/psp.yaml
+++ b/helm-charts/FATE/templates/psp.yaml
@@ -14,7 +14,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:
-    fateMoudle: psp
+    fateModule: psp
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 spec:

--- a/helm-charts/FATE/templates/role.yaml
+++ b/helm-charts/FATE/templates/role.yaml
@@ -14,7 +14,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    fateMoudle: role
+    fateModule: role
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 rules:

--- a/helm-charts/FATE/templates/rolebinding.yaml
+++ b/helm-charts/FATE/templates/rolebinding.yaml
@@ -14,7 +14,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    fateMoudle: serviceAccount
+    fateModule: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 roleRef:

--- a/helm-charts/FATE/templates/serviceaccount.yaml
+++ b/helm-charts/FATE/templates/serviceaccount.yaml
@@ -14,7 +14,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    fateMoudle: serviceAccount
+    fateModule: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

The label's key should be module, not moudle.

