### PR TITLE
Part 3: Fum shutdown flow

### DIFF
--- a/docker-build/fate-upgrade-manager/Dockerfile
+++ b/docker-build/fate-upgrade-manager/Dockerfile
@@ -2,7 +2,7 @@ FROM centos/python-36-centos7
 
 WORKDIR /
 
-COPY sql/ .
+COPY sql/ ./sql/
 COPY upgrade-mysql.py .
 COPY shutdown-flow.py .
 

--- a/docker-build/fate-upgrade-manager/Dockerfile
+++ b/docker-build/fate-upgrade-manager/Dockerfile
@@ -1,0 +1,11 @@
+FROM centos/python-36-centos7
+
+WORKDIR /
+
+COPY sql/ .
+COPY upgrade-mysql.py .
+COPY shutdown-flow.py .
+
+RUN pip install --upgrade pip && \
+    pip install mysql-connector-python && \
+    pip install kubernetes

--- a/docker-build/fate-upgrade-manager/shutdown-flow.py
+++ b/docker-build/fate-upgrade-manager/shutdown-flow.py
@@ -25,7 +25,7 @@ def shutdown_flow(namespace, api, app):
             print("wait for 10 seconds and will recheck")
             time.sleep(10)
     print("cannot shutdown the flow's pod")
-    return -1
+    return 1
 
 
 def get_flow_app(namespace, api):

--- a/docker-build/fate-upgrade-manager/shutdown-flow.py
+++ b/docker-build/fate-upgrade-manager/shutdown-flow.py
@@ -1,0 +1,80 @@
+import sys
+import time
+from kubernetes import client, config
+from enum import Enum
+
+APP_NAME = "python"
+
+
+class AppType(Enum):
+    DEPLOYMENT = 1
+    STS = 2
+
+
+def shutdown_flow(namespace, api, app_type):
+    if app_type == AppType.DEPLOYMENT:
+        resp = update_deployment(namespace, api)
+    else:
+        resp = update_sts(namespace, api)
+    if resp.status.replicas == 0:
+        print("Shut down flow succeed")
+    else:
+        print("Shut down flow failed")
+        exit(-1)
+
+
+def check_flow_type(namespace, api):
+    deployments = api.list_namespaced_deployment(namespace)
+    for deployment in deployments.items:
+        if deployment.metadata.name == APP_NAME:
+            return AppType.DEPLOYMENT
+    return AppType.STS
+
+
+def update_deployment(namespace, api):
+    # Update container image
+    body = client.V1Deployment(
+        spec=client.V1DeploymentSpec(
+            replicas=0
+        )
+    )
+    return api.patch_namespaced_deployment(
+        name=APP_NAME, namespace=namespace, body=body
+    )
+
+
+def update_sts(namespace, api):
+    body = client.V1StatefulSet(
+        spec=client.V1StatefulSetSpec(
+            replicas=0
+        )
+    )
+    return api.patch_namespaced_stateful_set(
+        name=APP_NAME, namespace=namespace, body=body
+    )
+
+
+def wait_flow_down(namespace, api):
+    flow_down = False
+    while True:
+        if flow_down:
+            return
+        rss = api.list_namespaced_replica_set(namespace)
+        for rs in rss.items:
+            if rs.metadata.name.startwith(APP_NAME):
+                if rs.status.ready_replicas == 0:
+                    flow_down = True
+                else:
+                    print("flow is still up, will check 10 seconds later")
+                    time.sleep(10)
+                break
+    return
+
+
+if __name__ == '__main__':
+    _, namespace = sys.argv
+    config.load_kube_config()
+    apps_v1 = client.AppsV1Api()
+    app_type = check_flow_type(namespace, apps_v1)
+    shutdown_flow(namespace, apps_v1, app_type)
+    wait_flow_down(namespace, apps_v1)

--- a/docker-build/fate-upgrade-manager/sql/1.6.0-1.6.1.sql
+++ b/docker-build/fate-upgrade-manager/sql/1.6.0-1.6.1.sql
@@ -1,0 +1,4 @@
+ALTER TABLE t_job ADD f_user LONGTEXT NOT NULL;
+UPDATE t_job SET f_user = '{}' WHERE f_user = '';
+
+ALTER TABLE t_task ADD f_engine_conf LONGTEXT;

--- a/docker-build/fate-upgrade-manager/sql/1.6.1-1.7.0.sql
+++ b/docker-build/fate-upgrade-manager/sql/1.6.1-1.7.0.sql
@@ -1,0 +1,169 @@
+ALTER TABLE t_job DROP f_work_mode;
+
+ALTER TABLE t_task ADD f_component_module VARCHAR(200) NOT NULL, ADD INDEX task_f_component_module (f_component_module);
+ALTER TABLE t_task ADD f_auto_retries INT NOT NULL DEFAULT 0, ADD INDEX task_f_auto_retries (f_auto_retries);
+ALTER TABLE t_task ADD f_auto_retry_delay INT NOT NULL DEFAULT 0;
+ALTER TABLE t_task ADD f_worker_id VARCHAR(100), ADD INDEX task_f_worker_id (f_worker_id);
+ALTER TABLE t_task ADD f_cmd LONGTEXT;
+ALTER TABLE t_task ADD f_provider_info LONGTEXT NOT NULL;
+UPDATE t_task SET f_provider_info = '{}' WHERE f_provider_info = '';
+ALTER TABLE t_task ADD f_component_parameters LONGTEXT NOT NULL;
+UPDATE t_task SET f_component_parameters = '{}' WHERE f_component_parameters = '';
+
+ALTER TABLE t_machine_learning_model_info DROP f_work_mode;
+
+CREATE TABLE t_data_table_tracking (
+    f_table_id BIGINT NOT NULL AUTO_INCREMENT,
+    f_create_time BIGINT,
+    f_create_date DATETIME,
+    f_update_time BIGINT,
+    f_update_date DATETIME,
+    f_table_name VARCHAR(300),
+    f_table_namespace VARCHAR(300),
+    f_job_id VARCHAR(25),
+    f_have_parent BOOL NOT NULL DEFAULT FALSE,
+    f_parent_number INT NOT NULL DEFAULT 0,
+    f_parent_table_name VARCHAR(500),
+    f_parent_table_namespace VARCHAR(500),
+    f_source_table_name VARCHAR(500),
+    f_source_table_namespace VARCHAR(500),
+
+    PRIMARY KEY (f_table_id),
+    INDEX datatabletracking_f_table_name (f_table_name),
+    INDEX datatabletracking_f_table_namespace (f_table_namespace),
+    INDEX datatabletracking_f_job_id (f_job_id)
+);
+
+CREATE TABLE t_cache_record (
+    f_cache_key VARCHAR(500) NOT NULL,
+    f_create_time BIGINT,
+    f_create_date DATETIME,
+    f_update_time BIGINT,
+    f_update_date DATETIME,
+    f_cache LONGTEXT NOT NULL,
+    f_job_id VARCHAR(25),
+    f_role VARCHAR(50),
+    f_party_id VARCHAR(10),
+    f_component_name TEXT,
+    f_task_id VARCHAR(100),
+    f_task_version BIGINT,
+    f_cache_name VARCHAR(50),
+    t_ttl BIGINT NOT NULL DEFAULT 0,
+
+    PRIMARY KEY (f_cache_key),
+    INDEX cacherecord_f_job_id (f_job_id),
+    INDEX cacherecord_f_role (f_role),
+    INDEX cacherecord_f_party_id (f_party_id),
+    INDEX cacherecord_f_task_id (f_task_id),
+    INDEX cacherecord_f_task_version (f_task_version)
+);
+
+CREATE TABLE t_component_registry (
+    f_create_time BIGINT,
+    f_create_date DATETIME,
+    f_update_time BIGINT,
+    f_update_date DATETIME,
+    f_provider_name VARCHAR(20) NOT NULL,
+    f_version VARCHAR(10) NOT NULL,
+    f_component_name VARCHAR(30) NOT NULL,
+    f_module VARCHAR(128) NOT NULL,
+
+    PRIMARY KEY (f_provider_name, f_version, f_component_name),
+    INDEX componentregistryinfo_f_provider_name (f_provider_name),
+    INDEX componentregistryinfo_f_version (f_version),
+    INDEX componentregistryinfo_f_component_name (f_component_name)
+);
+
+CREATE TABLE t_component_provider_info (
+    f_create_time BIGINT,
+    f_create_date DATETIME,
+    f_update_time BIGINT,
+    f_update_date DATETIME,
+    f_provider_name VARCHAR(20) NOT NULL,
+    f_version VARCHAR(10) NOT NULL,
+    f_class_path LONGTEXT NOT NULL,
+    f_path VARCHAR(128) NOT NULL,
+    f_python VARCHAR(128) NOT NULL,
+
+    PRIMARY KEY (f_provider_name, f_version),
+    INDEX componentproviderinfo_f_provider_name (f_provider_name),
+    INDEX componentproviderinfo_f_version (f_version)
+);
+
+CREATE TABLE t_component_info (
+    f_component_name VARCHAR(30) NOT NULL,
+    f_create_time BIGINT,
+    f_create_date DATETIME,
+    f_update_time BIGINT,
+    f_update_date DATETIME,
+    f_component_alias LONGTEXT NOT NULL,
+    f_default_provider VARCHAR(20) NOT NULL,
+    f_support_provider LONGTEXT,
+
+    PRIMARY KEY (f_component_name)
+);
+
+CREATE TABLE t_worker (
+    f_worker_id VARCHAR(100) NOT NULL,
+    f_create_time BIGINT,
+    f_create_date DATETIME,
+    f_update_time BIGINT,
+    f_update_date DATETIME,
+    f_worker_name VARCHAR(50) NOT NULL,
+    f_job_id VARCHAR(25) NOT NULL,
+    f_task_id VARCHAR(100) NOT NULL,
+    f_task_version BIGINT NOT NULL,
+    f_role VARCHAR(50) NOT NULL,
+    f_party_id VARCHAR(10) NOT NULL,
+    f_run_ip VARCHAR(100),
+    f_run_pid INT,
+    f_http_port INT,
+    f_grpc_port INT,
+    f_config LONGTEXT,
+    f_cmd LONGTEXT,
+    f_start_time BIGINT,
+    f_start_date DATETIME,
+    f_end_time BIGINT,
+    f_end_date DATETIME,
+
+    PRIMARY KEY (f_worker_id),
+    INDEX workerinfo_f_worker_name (f_worker_name),
+    INDEX workerinfo_f_job_id (f_job_id),
+    INDEX workerinfo_f_task_id (f_task_id),
+    INDEX workerinfo_f_task_version (f_task_version),
+    INDEX workerinfo_f_role (f_role),
+    INDEX workerinfo_f_party_id (f_party_id)
+);
+
+CREATE TABLE t_dependencies_storage_meta (
+    f_create_time BIGINT,
+    f_create_date DATETIME,
+    f_update_time BIGINT,
+    f_update_date DATETIME,
+    f_storage_engine VARCHAR(30) NOT NULL,
+    f_type VARCHAR(20) NOT NULL,
+    f_version VARCHAR(10) NOT NULL,
+    f_storage_path VARCHAR(256),
+    f_snapshot_time BIGINT,
+    f_fate_flow_snapshot_time BIGINT,
+    f_dependencies_conf LONGTEXT,
+    f_upload_status BOOL NOT NULL DEFAULT FALSE,
+    f_pid INT,
+
+    PRIMARY KEY (f_storage_engine, f_type, f_version),
+    INDEX dependenciesstoragemeta_f_version (f_version)
+);
+
+ALTER TABLE t_storage_table_meta CHANGE f_type f_store_type VARCHAR(50), RENAME INDEX storagetablemetamodel_f_type TO storagetablemetamodel_f_store_type;
+ALTER TABLE t_storage_table_meta ADD f_extend_sid BOOL NOT NULL DEFAULT FALSE;
+ALTER TABLE t_storage_table_meta ADD f_auto_increasing_sid BOOL NOT NULL DEFAULT FALSE;
+ALTER TABLE t_storage_table_meta ADD f_read_access_time BIGINT;
+ALTER TABLE t_storage_table_meta ADD f_read_access_date DATETIME;
+ALTER TABLE t_storage_table_meta ADD f_write_access_time BIGINT;
+ALTER TABLE t_storage_table_meta ADD f_write_access_date DATETIME;
+ALTER TABLE t_storage_table_meta MODIFY f_create_time BIGINT;
+
+ALTER TABLE t_session_record RENAME COLUMN f_session_id TO f_engine_session_id, ADD INDEX sessionrecord_f_engine_session_id (f_engine_session_id);
+ALTER TABLE t_session_record ADD f_manager_session_id VARCHAR(150) NOT NULL, ADD INDEX sessionrecord_f_manager_session_id (f_manager_session_id);
+ALTER TABLE t_session_record MODIFY f_create_time BIGINT, DROP INDEX sessionrecord_f_create_time;
+ALTER TABLE t_session_record DROP PRIMARY KEY, ADD PRIMARY KEY (f_engine_type, f_engine_name, f_engine_session_id);

--- a/docker-build/fate-upgrade-manager/sql/1.7.0-1.7.1.sql
+++ b/docker-build/fate-upgrade-manager/sql/1.7.0-1.7.1.sql
@@ -1,0 +1,4 @@
+ALTER TABLE t_job ADD f_inheritance_info LONGTEXT;
+ALTER TABLE t_job ADD f_inheritance_status VARCHAR(50);
+
+ALTER TABLE t_storage_table_meta MODIFY f_count BIGINT;

--- a/docker-build/fate-upgrade-manager/sql/1.7.1-1.7.2.sql
+++ b/docker-build/fate-upgrade-manager/sql/1.7.1-1.7.2.sql
@@ -1,0 +1,110 @@
+ALTER TABLE t_job DROP INDEX job_f_user_id;
+ALTER TABLE t_job DROP INDEX job_f_tag;
+ALTER TABLE t_job DROP INDEX job_f_initiator_role;
+ALTER TABLE t_job DROP INDEX job_f_initiator_party_id;
+ALTER TABLE t_job DROP INDEX job_f_status;
+ALTER TABLE t_job DROP INDEX job_f_status_code;
+ALTER TABLE t_job DROP INDEX job_f_is_initiator;
+ALTER TABLE t_job DROP INDEX job_f_ready_signal;
+ALTER TABLE t_job DROP INDEX job_f_cancel_signal;
+ALTER TABLE t_job DROP INDEX job_f_rerun_signal;
+ALTER TABLE t_job DROP INDEX job_f_engine_name;
+ALTER TABLE t_job DROP INDEX job_f_engine_type;
+ALTER TABLE t_job DROP INDEX job_f_cores;
+ALTER TABLE t_job DROP INDEX job_f_memory;
+ALTER TABLE t_job DROP INDEX job_f_remaining_cores;
+ALTER TABLE t_job DROP INDEX job_f_remaining_memory;
+ALTER TABLE t_job DROP INDEX job_f_resource_in_use;
+
+ALTER TABLE t_task DROP INDEX task_f_component_module;
+ALTER TABLE t_task DROP INDEX task_f_task_id;
+ALTER TABLE t_task DROP INDEX task_f_task_version;
+ALTER TABLE t_task DROP INDEX task_f_initiator_role;
+ALTER TABLE t_task DROP INDEX task_f_initiator_party_id;
+ALTER TABLE t_task DROP INDEX task_f_federated_mode;
+ALTER TABLE t_task DROP INDEX task_f_federated_status_collect_type;
+ALTER TABLE t_task DROP INDEX task_f_status_code;
+ALTER TABLE t_task DROP INDEX task_f_auto_retries;
+ALTER TABLE t_task DROP INDEX task_f_worker_id;
+ALTER TABLE t_task DROP INDEX task_f_party_status;
+
+ALTER TABLE trackingmetric DROP INDEX trackingmetric_f_metric_namespace;
+ALTER TABLE trackingmetric DROP INDEX trackingmetric_f_metric_name;
+ALTER TABLE trackingmetric DROP INDEX trackingmetric_f_type;
+
+ALTER TABLE trackingoutputdatainfo DROP INDEX trackingoutputdatainfo_f_task_version;
+
+ALTER TABLE t_machine_learning_model_info DROP INDEX machinelearningmodelinfo_f_role;
+ALTER TABLE t_machine_learning_model_info DROP INDEX machinelearningmodelinfo_f_party_id;
+ALTER TABLE t_machine_learning_model_info DROP INDEX machinelearningmodelinfo_f_initiator_role;
+ALTER TABLE t_machine_learning_model_info DROP INDEX machinelearningmodelinfo_f_initiator_party_id;
+
+ALTER TABLE t_data_table_tracking DROP INDEX datatabletracking_f_table_name;
+ALTER TABLE t_data_table_tracking DROP INDEX datatabletracking_f_table_namespace;
+
+ALTER TABLE t_cache_record DROP PRIMARY KEY, ADD id INT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST;
+ALTER TABLE t_cache_record DROP INDEX cacherecord_f_task_id;
+
+DROP PROCEDURE IF EXISTS alter_componentsummary;
+DELIMITER //
+
+CREATE PROCEDURE alter_componentsummary()
+BEGIN
+    DECLARE done BOOL DEFAULT FALSE;
+    DECLARE date_ CHAR(8);
+
+    DECLARE cur CURSOR FOR SELECT RIGHT(TABLE_NAME, 8) FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = (SELECT DATABASE()) AND TABLE_NAME LIKE 't\_component\_summary\_%';
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+    OPEN cur;
+
+    loop_: LOOP
+        FETCH cur INTO date_;
+        IF done THEN
+            LEAVE loop_;
+        END IF;
+
+        SET @sql = CONCAT('ALTER TABLE t_component_summary_', date_, ' DROP INDEX componentsummary_', date_, '_f_task_version');
+        PREPARE stmt FROM @sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END LOOP;
+
+    CLOSE cur;
+END //
+
+DELIMITER ;
+CALL alter_componentsummary();
+DROP PROCEDURE alter_componentsummary;
+
+ALTER TABLE t_model_operation_log DROP INDEX modeloperationlog_f_model_id;
+ALTER TABLE t_model_operation_log DROP INDEX modeloperationlog_f_model_version;
+
+ALTER TABLE t_engine_registry DROP INDEX engineregistry_f_cores;
+ALTER TABLE t_engine_registry DROP INDEX engineregistry_f_memory;
+ALTER TABLE t_engine_registry DROP INDEX engineregistry_f_remaining_cores;
+ALTER TABLE t_engine_registry DROP INDEX engineregistry_f_remaining_memory;
+ALTER TABLE t_engine_registry DROP INDEX engineregistry_f_nodes;
+
+ALTER TABLE t_worker DROP INDEX workerinfo_f_task_id;
+ALTER TABLE t_worker DROP INDEX workerinfo_f_role;
+
+CREATE TABLE t_storage_connector (
+    f_name VARCHAR(100) NOT NULL,
+    f_create_time BIGINT,
+    f_create_date DATETIME,
+    f_update_time BIGINT,
+    f_update_date DATETIME,
+    f_engine VARCHAR(100) NOT NULL,
+    f_connector_info LONGTEXT NOT NULL,
+
+    PRIMARY KEY (f_name),
+    INDEX storageconnectormodel_f_engine (f_engine)
+);
+
+ALTER TABLE t_storage_table_meta DROP INDEX storagetablemetamodel_f_engine;
+ALTER TABLE t_storage_table_meta DROP INDEX storagetablemetamodel_f_store_type;
+
+ALTER TABLE t_session_record DROP INDEX sessionrecord_f_engine_session_id;
+ALTER TABLE t_session_record DROP INDEX sessionrecord_f_manager_session_id;

--- a/docker-build/fate-upgrade-manager/sql/1.7.2-1.8.0.sql
+++ b/docker-build/fate-upgrade-manager/sql/1.7.2-1.8.0.sql
@@ -1,0 +1,2 @@
+ALTER TABLE t_storage_table_meta ADD f_origin VARCHAR(50) NOT NULL DEFAULT '';
+ALTER TABLE t_storage_table_meta ADD f_disable BOOL NOT NULL DEFAULT FALSE;

--- a/docker-build/fate-upgrade-manager/upgrade-mysql.py
+++ b/docker-build/fate-upgrade-manager/upgrade-mysql.py
@@ -1,0 +1,64 @@
+import mysql.connector
+import sys
+import os
+
+
+def get_script_list(start_ver, target_ver):
+    sql_script_names = os.listdir("sql")
+    sql_script_names.sort()
+    res = []
+    start_index = -1
+    end_index = -1
+    for i in range(len(sql_script_names)):
+        if sql_script_names[i].startswith(start_ver):
+            start_index = i
+        if sql_script_names[i].replace(".sql", "").endswith(target_ver):
+            end_index = i
+    if start_index == -1 or end_index == -1 or start_index > end_index:
+        return res
+    res = sql_script_names[start_index:end_index+1]
+    print("will run scripts:")
+    print(res)
+    return res
+
+
+def preprocess_script(script):
+    queries = []
+    query = ''
+    delimiter = ';'
+    with open("sql/%s" % script, "r") as sql_file:
+        for line in sql_file.readlines():
+            line = line.strip()
+            if line.startswith('DELIMITER'):
+                delimiter = line[10:]
+            else:
+                query += line+'\n'
+                if line.endswith(delimiter):
+                    # Get rid of the delimiter, remove any blank lines and add this query to our list
+                    queries.append(query.strip().strip(delimiter))
+                    query = ''
+    return queries
+
+
+def run_script(script, cursor):
+    queries = preprocess_script(script)
+    for query in queries:
+        if not query.strip():
+            continue
+        print("execute query %s" % query)
+        cursor.execute(query)
+
+
+if __name__ == '__main__':
+    _, user, password, start_ver, end_ver = sys.argv
+    scripts_to_run = get_script_list(start_ver, end_ver)
+    mydb = mysql.connector.connect(
+        host="mysql",
+        user=user,
+        password=password,
+        database="eggroll_meta"
+    )
+    cursor = mydb.cursor()
+    for script in scripts_to_run:
+        run_script(script, cursor)
+    cursor.close()

--- a/helm-charts/UpgradeManager/templates/fate-mysql-upgrade-job.yaml
+++ b/helm-charts/UpgradeManager/templates/fate-mysql-upgrade-job.yaml
@@ -16,12 +16,12 @@ spec:
             - "-c"
             - |
               python shutdown-flow.py {{ .Release.Namespace }}
-              retVal = $?
+              retVal=$?
               if [ $retVal -ne 0 ]; then
                 echo "failed to terminate the flow's pod"
               else
                 {{- with .Values }}
-                python upgrade-mysql.py {{ .username }} {{ .password }} {{ .start }} {{ .target }}w
+                python upgrade-mysql.py {{ .username }} {{ .password }} {{ .start }} {{ .target }}
                 {{- end }}
               fi
       restartPolicy: Never

--- a/helm-charts/UpgradeManager/templates/fate-mysql-upgrade-job.yaml
+++ b/helm-charts/UpgradeManager/templates/fate-mysql-upgrade-job.yaml
@@ -1,6 +1,5 @@
 apiVersion: batch/v1
 kind: Job
-{{- with .Values }}
 metadata:
   name: fate-mysql-upgrade-job-{{ .start }}-to-{{ .target }}
 spec:
@@ -16,7 +15,8 @@ spec:
             - "/bin/bash"
             - "-c"
             - |
-              python shutdown-flow.py {{ .namespace }}
-              python upgrade-mysql.py {{ .username }} {{ .password }} {{ .start }} {{ .target }}
+              python shutdown-flow.py {{ .Release.Namespace }}
+              {{- with .Values }}
+              python upgrade-mysql.py {{ .username }} {{ .password }} {{ .start }} {{ .target }}w
+              {{- end }}
       restartPolicy: Never
-{{- end }}

--- a/helm-charts/UpgradeManager/templates/fate-mysql-upgrade-job.yaml
+++ b/helm-charts/UpgradeManager/templates/fate-mysql-upgrade-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: fate-mysql-upgrade-job-{{ .start }}-to-{{ .target }}
 spec:
-  backoffLimit: 1
+  backoffLimit: 0
   template:
     spec:
       serviceAccountName: fum

--- a/helm-charts/UpgradeManager/templates/fate-mysql-upgrade-job.yaml
+++ b/helm-charts/UpgradeManager/templates/fate-mysql-upgrade-job.yaml
@@ -12,7 +12,11 @@ spec:
         - name: fate-mysql-upgrader
           image: federatedai/fate-upgrade-manager:latest
           imagePullPolicy: IfNotPresent
-          command: ["python", "upgrade-mysql.py", "{{ .username }}",
-                    "{{ .password }}", "{{ .start }}", "{{ .target }}"]
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              python shutdown-flow.py {{ .namespace }}
+              python upgrade-mysql.py {{ .username }} {{ .password }} {{ .start }} {{ .target }}
       restartPolicy: Never
 {{- end }}

--- a/helm-charts/UpgradeManager/templates/fate-mysql-upgrade-job.yaml
+++ b/helm-charts/UpgradeManager/templates/fate-mysql-upgrade-job.yaml
@@ -7,6 +7,7 @@ spec:
   backoffLimit: 1
   template:
     spec:
+      serviceAccountName: fum
       containers:
         - name: fate-mysql-upgrader
           image: federatedai/fate-upgrade-manager:latest

--- a/helm-charts/UpgradeManager/templates/fate-mysql-upgrade-job.yaml
+++ b/helm-charts/UpgradeManager/templates/fate-mysql-upgrade-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: fate-mysql-upgrade-job-{{ .start }}-to-{{ .target }}
+  name: fate-mysql-upgrade-job
 spec:
   backoffLimit: 0
   template:
@@ -16,7 +16,12 @@ spec:
             - "-c"
             - |
               python shutdown-flow.py {{ .Release.Namespace }}
-              {{- with .Values }}
-              python upgrade-mysql.py {{ .username }} {{ .password }} {{ .start }} {{ .target }}w
-              {{- end }}
+              retVal = $?
+              if [ $retVal -ne 0 ]; then
+                echo "failed to terminate the flow's pod"
+              else
+                {{- with .Values }}
+                python upgrade-mysql.py {{ .username }} {{ .password }} {{ .start }} {{ .target }}w
+                {{- end }}
+              fi
       restartPolicy: Never

--- a/helm-charts/UpgradeManager/templates/rbac.yaml
+++ b/helm-charts/UpgradeManager/templates/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: fum
   namespace: {{ .Release.Namespace }}
@@ -28,6 +28,7 @@ rules:
   - apps
   resources:
   - deployments
+  - deployments/status
   - statefulsets
   verbs:
   - update

--- a/helm-charts/UpgradeManager/templates/rbac.yaml
+++ b/helm-charts/UpgradeManager/templates/rbac.yaml
@@ -2,11 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: fum
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: fum
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -14,11 +16,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: fum
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: fum-role
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - apps
@@ -28,3 +32,5 @@ rules:
   verbs:
   - update
   - patch
+  - list
+  - get

--- a/helm-charts/UpgradeManager/templates/rbac.yaml
+++ b/helm-charts/UpgradeManager/templates/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fum
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fum
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fum-role
+subjects:
+  - kind: ServiceAccount
+    name: fum
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fum-role
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - update
+  - patch

--- a/helm-charts/UpgradeManager/templates/rbac.yaml
+++ b/helm-charts/UpgradeManager/templates/rbac.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: fum-role
 subjects:
   - kind: ServiceAccount
@@ -19,7 +19,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: fum-role
   namespace: {{ .Release.Namespace }}

--- a/helm-charts/UpgradeManager/values.yaml
+++ b/helm-charts/UpgradeManager/values.yaml
@@ -1,3 +1,4 @@
+namespace: fate-9999
 username: fate
 password: fate_dev
 start: 1.9.0

--- a/helm-charts/UpgradeManager/values.yaml
+++ b/helm-charts/UpgradeManager/values.yaml
@@ -1,4 +1,3 @@
-namespace: fate-9999
 username: fate
 password: fate_dev
 start: 1.9.0


### PR DESCRIPTION
Fix: #556 

### NOTE: the files under the docker-build folder will not be checkin. They will be put in the fate-builder folder. I put they here to let you have a full picture.

## Description
1. Create a service account called fum.
2. Add another python script in the fum image to help to shut down fateflow.
3. The python script use the service account to get/update the deployement/sts. 

## Test
1. Install a 1.7.1 cluster.
2. run `helm install upgrade . -f values.yaml  -n fate-9999`, which will be run by KubeFATE in the future. In this change we run it manually to simulate KubeFATE.
3. Check the log of the job pod:
```
change the replicas to 0 successfully
will run scripts:
['1.7.1-1.7.2.sql']
execute query ALTER TABLE t_job DROP INDEX job_f_user_id
execute query ALTER TABLE t_job DROP INDEX job_f_tag
execute query ALTER TABLE t_job DROP INDEX job_f_initiator_role
...
...
...
execute query ALTER TABLE t_session_record DROP INDEX sessionrecord_f_engine_session_id
execute query ALTER TABLE t_session_record DROP INDEX sessionrecord_f_manager_session_id
```
4. Verified that the db is really changed.
5. Upgrade the cluster to 1.7.2, succeed.

------

Test after the latest change:
```
01:47:11 root@control-plane UpgradeManager ±|fum-shutdown-flow ✗|→ klon fate-9999 fate-mysql-upgrade-job-856f2
the ready replicas number is 1
wait for 10 seconds and will recheck
the ready replicas number is None
sleep for another 30 seconds, make sure the flow's pod is down
will run scripts:
['1.7.2-1.8.0.sql']
execute query ALTER TABLE t_storage_table_meta ADD f_origin VARCHAR(50) NOT NULL DEFAULT ''
execute query ALTER TABLE t_storage_table_meta ADD f_disable BOOL NOT NULL DEFAULT FALSE
```
