### PR TITLE
Fix the issue found when trying to uprade to v1.9.0

### DIFF
--- a/helm-charts/FATE-Exchange/templates/nginx.yaml
+++ b/helm-charts/FATE-Exchange/templates/nginx.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: nginx-config
   labels:
-    fateModule: nginx
+    fateMoudle: nginx
 {{ include "fate.labels" . | indent 4 }}
 data:
   route_table.yaml: |
@@ -113,7 +113,7 @@ kind: Deployment
 metadata:
   name: nginx
   labels:
-    fateModule: nginx
+    fateMoudle: nginx
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: {{ default 1 .Values.modules.nginx.replicas }}
@@ -121,12 +121,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: nginx
+      fateMoudle: nginx
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: nginx
+        fateMoudle: nginx
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:
@@ -177,7 +177,7 @@ kind: Service
 metadata:
   name: nginx
   labels:
-    fateModule: nginx
+    fateMoudle: nginx
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -200,7 +200,7 @@ spec:
   loadBalancerIP: "{{ .Values.modules.nginx.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateModule: nginx
+    fateMoudle: nginx
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{ end }}

--- a/helm-charts/FATE-Exchange/templates/psp.yaml
+++ b/helm-charts/FATE-Exchange/templates/psp.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:
-    fateModule: psp
+    fateMoudle: psp
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 spec:

--- a/helm-charts/FATE-Exchange/templates/role.yaml
+++ b/helm-charts/FATE-Exchange/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    fateModule: role
+    fateMoudle: role
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 rules:

--- a/helm-charts/FATE-Exchange/templates/rolebinding.yaml
+++ b/helm-charts/FATE-Exchange/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    fateModule: serviceAccount
+    fateMoudle: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 roleRef:

--- a/helm-charts/FATE-Exchange/templates/rollsite-module.yaml
+++ b/helm-charts/FATE-Exchange/templates/rollsite-module.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: rollsite-config
   labels:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.labels" . | indent 4 }}
 data:
   eggroll.properties: |
@@ -85,7 +85,7 @@ kind: Deployment
 metadata:
   name: rollsite
   labels:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -93,12 +93,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: rollsite
+      fateMoudle: rollsite
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: rollsite
+        fateMoudle: rollsite
 {{ include "fate.labels" . | indent 8 }}
     spec:
       hostAliases:
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: rollsite
   labels:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -177,7 +177,7 @@ spec:
   loadBalancerIP: "{{ .Values.modules.rollsite.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{ end }}

--- a/helm-charts/FATE-Exchange/templates/serviceaccount.yaml
+++ b/helm-charts/FATE-Exchange/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    fateModule: serviceAccount
+    fateMoudle: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 {{- end -}}

--- a/helm-charts/FATE-Exchange/templates/traffic-server-module.yaml
+++ b/helm-charts/FATE-Exchange/templates/traffic-server-module.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: traffic-server-config
   labels:
-    fateModule: traffic-server
+    fateMoudle: traffic-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote }}
     owner: kubefate
@@ -46,7 +46,7 @@ apiVersion: v1
 metadata:
   name: traffic-server-sni
   labels:
-    fateModule: traffic-server
+    fateMoudle: traffic-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote }}
     owner: kubefate
@@ -64,7 +64,7 @@ kind: Deployment
 metadata:
   name: traffic-server
   labels:
-    fateModule: traffic-server
+    fateMoudle: traffic-server
     name: {{ .Values.partyName  | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -75,13 +75,13 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: traffic-server
+      fateMoudle: traffic-server
       name: {{ .Values.partyName  | quote }}
       partyId: {{ .Values.partyId | quote  }}
   template:
     metadata:
       labels:
-        fateModule: traffic-server
+        fateMoudle: traffic-server
         name: {{ .Values.partyName | quote  }}
         partyId: {{ .Values.partyId | quote  }}
         owner: kubefate
@@ -148,7 +148,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    fateModule: traffic-server
+    fateMoudle: traffic-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote }}
     owner: kubefate
@@ -166,7 +166,7 @@ spec:
   loadBalancerIP: "{{ .Values.modules.trafficServer.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateModule: traffic-server
+    fateMoudle: traffic-server
     name: {{ .Values.partyName | quote }}
     partyId: {{ .Values.partyId | quote  }}
 ---

--- a/helm-charts/FATE-Serving/templates/ingress.yaml
+++ b/helm-charts/FATE-Serving/templates/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: serving-proxy
   labels:
-    fateModule: serving-proxy
+    fateMoudle: serving-proxy
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -52,7 +52,7 @@ kind: Ingress
 metadata:
   name: serving-admin
   labels:
-    fateModule: serving-admin
+    fateMoudle: serving-admin
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate

--- a/helm-charts/FATE-Serving/templates/istio.yaml
+++ b/helm-charts/FATE-Serving/templates/istio.yaml
@@ -31,7 +31,7 @@ kind: VirtualService
 metadata:
   name: fate-serving-ingress
   labels:
-      fateModule: serving-proxy
+      fateMoudle: serving-proxy
       name: {{ .Values.partyName | quote  }}
       partyId: {{ .Values.partyId | quote  }}
       owner: kubefate

--- a/helm-charts/FATE-Serving/templates/psp.yaml
+++ b/helm-charts/FATE-Serving/templates/psp.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:
-    fateModule: psp
+    fateMoudle: psp
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 spec:

--- a/helm-charts/FATE-Serving/templates/role.yaml
+++ b/helm-charts/FATE-Serving/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    fateModule: role
+    fateMoudle: role
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 rules:

--- a/helm-charts/FATE-Serving/templates/rolebinding.yaml
+++ b/helm-charts/FATE-Serving/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    fateModule: serviceAccount
+    fateMoudle: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 roleRef:

--- a/helm-charts/FATE-Serving/templates/serviceaccount.yaml
+++ b/helm-charts/FATE-Serving/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    fateModule: serviceAccount
+    fateMoudle: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 {{- end -}}

--- a/helm-charts/FATE-Serving/templates/serving-admin-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-admin-module.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: serving-admin-config
   labels:
-    fateModule: serving-admin
+    fateMoudle: serving-admin
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -44,7 +44,7 @@ kind: Deployment
 metadata:
   name: serving-admin
   labels:
-    fateModule: serving-admin
+    fateMoudle: serving-admin
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -55,13 +55,13 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: serving-admin
+      fateMoudle: serving-admin
       name: {{ .Values.partyName | quote  }}
       partyId: {{ .Values.partyId | quote  }}
   template:
     metadata:
       labels:
-        fateModule: serving-admin
+        fateMoudle: serving-admin
         name: {{ .Values.partyName | quote  }}
         partyId: {{ .Values.partyId | quote  }}
         owner: kubefate
@@ -104,7 +104,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    fateModule: serving-admin
+    fateMoudle: serving-admin
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -121,7 +121,7 @@ spec:
       protocol: TCP
   type: {{ .Values.servingAdmin.type }}
   selector:
-    fateModule: serving-admin
+    fateMoudle: serving-admin
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
 {{ end }}

--- a/helm-charts/FATE-Serving/templates/serving-proxy-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-proxy-module.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: serving-proxy-config
   labels:
-    fateModule: serving-proxy
+    fateMoudle: serving-proxy
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote }}
     owner: kubefate
@@ -133,7 +133,7 @@ kind: Deployment
 metadata:
   name: serving-proxy
   labels:
-    fateModule: serving-proxy
+    fateMoudle: serving-proxy
     name: {{ .Values.partyName  | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -144,13 +144,13 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: serving-proxy
+      fateMoudle: serving-proxy
       name: {{ .Values.partyName  | quote }}
       partyId: {{ .Values.partyId | quote  }}
   template:
     metadata:
       labels:
-        fateModule: serving-proxy
+        fateMoudle: serving-proxy
         name: {{ .Values.partyName | quote  }}
         partyId: {{ .Values.partyId | quote  }}
         owner: kubefate
@@ -206,7 +206,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    fateModule: serving-proxy
+    fateMoudle: serving-proxy
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote }}
     owner: kubefate
@@ -232,7 +232,7 @@ spec:
   loadBalancerIP: "{{ .Values.servingProxy.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateModule: serving-proxy
+    fateMoudle: serving-proxy
     name: {{ .Values.partyName | quote }}
     partyId: {{ .Values.partyId | quote  }}
 ---

--- a/helm-charts/FATE-Serving/templates/serving-redis-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-redis-module.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: serving-redis-config
   labels:
-    fateModule: serving-redis
+    fateMoudle: serving-redis
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId  | quote }}
     owner: kubefate
@@ -31,7 +31,7 @@ kind: Deployment
 metadata:
   name: serving-redis
   labels:
-    fateModule: serving-redis
+    fateMoudle: serving-redis
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -42,13 +42,13 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: serving-redis
+      fateMoudle: serving-redis
       name: {{ .Values.partyName | quote  }}
       partyId: {{ .Values.partyId | quote  }}
   template:
     metadata:
       labels:
-        fateModule: serving-redis
+        fateMoudle: serving-redis
         name: {{ .Values.partyName | quote  }}
         partyId: {{ .Values.partyId | quote  }}
         owner: kubefate
@@ -114,7 +114,7 @@ kind: Service
 metadata:
   name: serving-redis
   labels:
-    fateModule: serving-redis
+    fateMoudle: serving-redis
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -126,7 +126,7 @@ spec:
       targetPort: 6379
       protocol: TCP
   selector:
-    fateModule: serving-redis
+    fateMoudle: serving-redis
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
 ---
@@ -136,7 +136,7 @@ apiVersion: v1
 metadata:
   name: serving-redis-data
   labels:
-    fateModule: serving-redis
+    fateMoudle: serving-redis
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate

--- a/helm-charts/FATE-Serving/templates/serving-server-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-server-module.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: serving-server-config
   labels:
-    fateModule: serving-server
+    fateMoudle: serving-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -73,7 +73,7 @@ kind: Deployment
 metadata:
   name: serving-server
   labels:
-    fateModule: serving-server
+    fateMoudle: serving-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -84,13 +84,13 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: serving-server
+      fateMoudle: serving-server
       name: {{ .Values.partyName | quote  }}
       partyId: {{ .Values.partyId | quote  }}
   template:
     metadata:
       labels:
-        fateModule: serving-server
+        fateMoudle: serving-server
         name: {{ .Values.partyName | quote  }}
         partyId: {{ .Values.partyId | quote  }}
         owner: kubefate
@@ -145,7 +145,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    fateModule: serving-server
+    fateMoudle: serving-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -165,7 +165,7 @@ spec:
   loadBalancerIP: "{{ .Values.servingServer.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateModule: serving-server
+    fateMoudle: serving-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
 ---
@@ -175,7 +175,7 @@ apiVersion: v1
 metadata:
   name: serving-server-data
   labels:
-    fateModule: serving-server
+    fateMoudle: serving-server
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate

--- a/helm-charts/FATE-Serving/templates/serving-zookeeper-module.yaml
+++ b/helm-charts/FATE-Serving/templates/serving-zookeeper-module.yaml
@@ -16,7 +16,7 @@ kind: Service
 metadata:
   name: serving-zookeeper
   labels:
-    fateModule: serving-zookeeper
+    fateMoudle: serving-zookeeper
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -34,7 +34,7 @@ spec:
       port: 3888
       targetPort: election
   selector:
-    fateModule: serving-zookeeper
+    fateMoudle: serving-zookeeper
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
 ---
@@ -44,7 +44,7 @@ kind: StatefulSet
 metadata:
   name: serving-zookeeper
   labels:
-    fateModule: serving-zookeeper
+    fateMoudle: serving-zookeeper
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate
@@ -57,14 +57,14 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      fateModule: serving-zookeeper
+      fateMoudle: serving-zookeeper
       name: {{ .Values.partyName | quote }}
       partyId: {{ .Values.partyId | quote }}
   template:
     metadata:
       name: serving-zookeeper
       labels:
-        fateModule: serving-zookeeper
+        fateMoudle: serving-zookeeper
         name: {{ .Values.partyName | quote }}
         partyId: {{ .Values.partyId | quote }}
         owner: kubefate
@@ -205,7 +205,7 @@ spec:
     - metadata:
         name: data
         labels:
-          fateModule: serving-zookeeper
+          fateMoudle: serving-zookeeper
           name: {{ .Values.partyName | quote }}
           partyId: {{ .Values.partyId | quote }}
           owner: kubefate

--- a/helm-charts/FATE/templates/backends/eggroll/clustermanager/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/clustermanager/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: clustermanager
   labels:
-    fateModule: clustermanager
+    fateMoudle: clustermanager
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: clustermanager
+      fateMoudle: clustermanager
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: clustermanager
+        fateMoudle: clustermanager
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:

--- a/helm-charts/FATE/templates/backends/eggroll/clustermanager/service.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/clustermanager/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: clustermanager
   labels:
-    fateModule: clustermanager
+    fateMoudle: clustermanager
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -26,6 +26,6 @@ spec:
   type: {{ .Values.modules.clustermanager.type }}
   clusterIP: None
   selector:
-    fateModule: clustermanager
+    fateMoudle: clustermanager
 {{ include "fate.matchLabels" . | indent 4 }}
 {{ end }}

--- a/helm-charts/FATE/templates/backends/eggroll/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: eggroll-config
   labels:
-    fateModule: eggroll
+    fateMoudle: eggroll
     name: {{ .Values.partyName | quote  }}
     partyId: {{ .Values.partyId | quote  }}
     owner: kubefate

--- a/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: rollsite-config
   labels:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.labels" . | indent 4 }}
 data:
   route_table.json: |

--- a/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: rollsite
   labels:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: rollsite
+      fateMoudle: rollsite
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: rollsite
+        fateMoudle: rollsite
 {{ include "fate.labels" . | indent 8 }}
     spec:
       hostAliases:

--- a/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/service.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/lb-rollsite/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: rollsite
   labels:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -31,7 +31,7 @@ spec:
   loadBalancerIP: "{{ .Values.modules.lbrollsite.loadBalancerIP }}"
 {{- end }}
   selector:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 apiVersion: v1
@@ -39,7 +39,7 @@ kind: Service
 metadata:
   name: exchange
   labels:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -52,7 +52,7 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.lbrollsite.type }}
   selector:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{ end }}

--- a/helm-charts/FATE/templates/backends/eggroll/nodemanager/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/nodemanager/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: fluentd-config
   labels:
-    fateModule: nodemanager
+    fateMoudle: nodemanager
 {{ include "fate.labels" . | indent 4 }}
 data:
   fluent.conf: |

--- a/helm-charts/FATE/templates/backends/eggroll/nodemanager/service.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/nodemanager/service.yaml
@@ -14,7 +14,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    fateModule: nodemanager
+    fateMoudle: nodemanager
 {{ include "fate.labels" . | indent 4 }}
   name: nodemanager
 spec:
@@ -25,6 +25,6 @@ spec:
       protocol: TCP
   clusterIP: None
   selector:
-    fateModule: nodemanager
+    fateMoudle: nodemanager
 {{ include "fate.matchLabels" . | indent 4 }}
 {{- end }}

--- a/helm-charts/FATE/templates/backends/eggroll/nodemanager/statefulSet.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/nodemanager/statefulSet.yaml
@@ -16,7 +16,7 @@ kind: StatefulSet
 metadata:
   name: nodemanager
   labels:
-    fateModule: nodemanager
+    fateMoudle: nodemanager
     app: nodemanager
 {{ include "fate.labels" . | indent 4 }}
 spec:
@@ -24,12 +24,12 @@ spec:
   serviceName: nodemanager
   selector:
     matchLabels:
-      fateModule: nodemanager
+      fateMoudle: nodemanager
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: nodemanager
+        fateMoudle: nodemanager
         app: nodemanager
 {{ include "fate.labels" . | indent 8 }}
     spec:
@@ -145,7 +145,7 @@ spec:
     - metadata:
         name: data-dir
         labels:
-          fateModule: nodemanager
+          fateMoudle: nodemanager
 {{ include "fate.labels" . | indent 10 }}
       spec:
         accessModes: [ {{ .Values.modules.nodemanager.accessMode | quote }} ]

--- a/helm-charts/FATE/templates/backends/eggroll/rollsite/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/rollsite/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: rollsite-config
   labels:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.labels" . | indent 4 }}
 data:
   route_table.json: |

--- a/helm-charts/FATE/templates/backends/eggroll/rollsite/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/rollsite/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: rollsite
   labels:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: rollsite
+      fateMoudle: rollsite
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: rollsite
+        fateMoudle: rollsite
 {{ include "fate.labels" . | indent 8 }}
     spec:
       hostAliases:

--- a/helm-charts/FATE/templates/backends/eggroll/rollsite/service.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/rollsite/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: rollsite
   labels:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -31,6 +31,6 @@ spec:
   loadBalancerIP: "{{ .Values.modules.rollsite.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateModule: rollsite
+    fateMoudle: rollsite
 {{ include "fate.matchLabels" . | indent 4 }}
 {{ end }}

--- a/helm-charts/FATE/templates/backends/spark/hdfs/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: namenode-config
   labels:
-    fateModule: namenode
+    fateMoudle: namenode
 {{ include "fate.labels" . | indent 4 }}
 data:
   core-site.xml: |
@@ -31,7 +31,7 @@ apiVersion: v1
 metadata:
   name: namenode-env
   labels:
-    fateModule: namenode
+    fateMoudle: namenode
 {{ include "fate.labels" . | indent 4 }}
 data:
   MULTIHOMED_NETWORK: "0"
@@ -87,7 +87,7 @@ apiVersion: v1
 metadata:
   name: datanode-env
   labels:
-    fateModule: datanode
+    fateMoudle: datanode
 {{ include "fate.labels" . | indent 4 }}
 data:
   MULTIHOMED_NETWORK: "0"

--- a/helm-charts/FATE/templates/backends/spark/hdfs/datanode.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/datanode.yaml
@@ -15,19 +15,19 @@ kind: StatefulSet
 metadata:
   name: datanode
   labels:
-    fateModule: datanode
+    fateMoudle: datanode
 {{ include "fate.labels" . | indent 4 }}
 spec:
   serviceName: datanode
   replicas: {{ .Values.modules.hdfs.datanode.replicas | default 3}}
   selector:
     matchLabels:
-      fateModule: datanode
+      fateMoudle: datanode
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: datanode
+        fateMoudle: datanode
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:
@@ -109,7 +109,7 @@ spec:
     - metadata:
         name: dfs
         labels:
-          fateModule: datanode
+          fateMoudle: datanode
 {{ include "fate.labels" . | indent 10 }}
       spec:
         accessModes: [{{ .Values.modules.hdfs.datanode.accessMode | quote }}]

--- a/helm-charts/FATE/templates/backends/spark/hdfs/namenode.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/namenode.yaml
@@ -15,19 +15,19 @@ kind: StatefulSet
 metadata:
   name: namenode
   labels:
-    fateModule: namenode
+    fateMoudle: namenode
 {{ include "fate.labels" . | indent 4 }}
 spec:
   serviceName: namenode
   replicas: 1
   selector:
     matchLabels:
-      fateModule: namenode
+      fateMoudle: namenode
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: namenode
+        fateMoudle: namenode
 {{ include "fate.labels" . | indent 8 }}
     spec:
     {{ if .Values.persistence.enabled }}
@@ -123,7 +123,7 @@ spec:
     - metadata:
         name: dfs
         labels:
-          fateModule: namenode
+          fateMoudle: namenode
 {{ include "fate.labels" . | indent 10 }}
       spec:
         accessModes: [{{ .Values.modules.hdfs.namenode.accessMode | quote }}]

--- a/helm-charts/FATE/templates/backends/spark/hdfs/service.yaml
+++ b/helm-charts/FATE/templates/backends/spark/hdfs/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: datanode
   labels:
-    fateModule: datanode
+    fateMoudle: datanode
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -33,7 +33,7 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.hdfs.datanode.type }}
   selector:
-    fateModule: datanode
+    fateMoudle: datanode
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 apiVersion: v1
@@ -41,7 +41,7 @@ kind: Service
 metadata:
   name: namenode
   labels:
-    fateModule: namenode
+    fateMoudle: namenode
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -62,7 +62,7 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.hdfs.namenode.type }}
   selector:
-    fateModule: namenode
+    fateMoudle: namenode
 {{ include "fate.matchLabels" . | indent 4 }}
 
 {{ end }}

--- a/helm-charts/FATE/templates/backends/spark/nginx/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/spark/nginx/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: nginx-config
   labels:
-    fateModule: nginx
+    fateMoudle: nginx
 {{ include "fate.labels" . | indent 4 }}
 data:
   route_table.yaml: |

--- a/helm-charts/FATE/templates/backends/spark/nginx/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/nginx/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: nginx
   labels:
-    fateModule: nginx
+    fateMoudle: nginx
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: nginx
+      fateMoudle: nginx
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: nginx
+        fateMoudle: nginx
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:

--- a/helm-charts/FATE/templates/backends/spark/nginx/service.yaml
+++ b/helm-charts/FATE/templates/backends/spark/nginx/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: nginx
   labels:
-    fateModule: nginx
+    fateMoudle: nginx
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -40,6 +40,6 @@ spec:
   {{- end }}
   
   selector:
-    fateModule: nginx
+    fateMoudle: nginx
 {{ include "fate.matchLabels" . | indent 4 }}
 {{ end }}

--- a/helm-charts/FATE/templates/backends/spark/pulsar/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/spark/pulsar/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: pulsar-config
   labels:
-    fateModule: pulsar
+    fateMoudle: pulsar
 {{ include "fate.labels" . | indent 4 }}
 data:
   standalone.conf: |

--- a/helm-charts/FATE/templates/backends/spark/pulsar/ingress.yaml
+++ b/helm-charts/FATE/templates/backends/spark/pulsar/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: pulsar
   labels:
-    fateModule: pulsar
+    fateMoudle: pulsar
 {{ include "fate.labels" . | indent 4 }}
 {{- if .Values.ingress.pulsar.annotations }}
   annotations:

--- a/helm-charts/FATE/templates/backends/spark/pulsar/service.yaml
+++ b/helm-charts/FATE/templates/backends/spark/pulsar/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: pulsar
   labels:
-    fateModule: pulsar
+    fateMoudle: pulsar
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -48,7 +48,7 @@ spec:
   {{- end }}
   
   selector:
-    fateModule: pulsar
+    fateMoudle: pulsar
 {{ include "fate.matchLabels" . | indent 4 }}
 
 ---
@@ -59,7 +59,7 @@ kind: Service
 metadata:
   name: pulsar-public-tls
   labels:
-    fateModule: pulsar
+    fateMoudle: pulsar
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -69,7 +69,7 @@ spec:
     protocol: TCP
   type: LoadBalancer
   selector:
-    fateModule: pulsar
+    fateMoudle: pulsar
 {{ include "fate.matchLabels" . | indent 4 }}
 {{- end }}
 

--- a/helm-charts/FATE/templates/backends/spark/pulsar/statefulSet.yaml
+++ b/helm-charts/FATE/templates/backends/spark/pulsar/statefulSet.yaml
@@ -15,19 +15,19 @@ kind: StatefulSet
 metadata:
   name: pulsar
   labels:
-    fateModule: pulsar
+    fateMoudle: pulsar
 {{ include "fate.labels" . | indent 4 }}
 spec:
   serviceName: pulsar
   replicas: 1
   selector:
     matchLabels:
-      fateModule: pulsar
+      fateMoudle: pulsar
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: pulsar
+        fateMoudle: pulsar
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:
@@ -133,7 +133,7 @@ spec:
     - metadata:
         name: pulsar-data
         labels:
-          fateModule: pulsar
+          fateMoudle: pulsar
 {{ include "fate.labels" . | indent 10 }}
       spec:
         accessModes: [{{ .Values.modules.pulsar.accessMode | quote }}]

--- a/helm-charts/FATE/templates/backends/spark/rabbitmq/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/spark/rabbitmq/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: rabbitmq-config
   labels:
-    fateModule: rabbitmq
+    fateMoudle: rabbitmq
 {{ include "fate.labels" . | indent 4 }}
 data:
   enabled_plugins: |

--- a/helm-charts/FATE/templates/backends/spark/rabbitmq/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/rabbitmq/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: rabbitmq
   labels:
-    fateModule: rabbitmq
+    fateMoudle: rabbitmq
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: 1
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: rabbitmq
+      fateMoudle: rabbitmq
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: rabbitmq
+        fateMoudle: rabbitmq
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:

--- a/helm-charts/FATE/templates/backends/spark/rabbitmq/ingress.yaml
+++ b/helm-charts/FATE/templates/backends/spark/rabbitmq/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: rabbitmq
   labels:
-    fateModule: rabbitmq
+    fateMoudle: rabbitmq
 {{ include "fate.labels" . | indent 4 }}
 {{- if .Values.ingress.rabbitmq.annotations }}
   annotations:

--- a/helm-charts/FATE/templates/backends/spark/rabbitmq/service.yaml
+++ b/helm-charts/FATE/templates/backends/spark/rabbitmq/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: rabbitmq
   labels:
-    fateModule: rabbitmq
+    fateMoudle: rabbitmq
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -35,7 +35,7 @@ spec:
   loadBalancerIP: "{{ .Values.modules.rabbitmq.loadBalancerIP }}"
   {{- end }}
   selector:
-    fateModule: rabbitmq
+    fateMoudle: rabbitmq
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{ end }}

--- a/helm-charts/FATE/templates/backends/spark/spark/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/spark/spark/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: spark-worker-config
   labels:
-    fateModule: spark-worker
+    fateMoudle: spark-worker
 {{ include "fate.labels" . | indent 4 }}
 data:
   service_conf.yaml: |

--- a/helm-charts/FATE/templates/backends/spark/spark/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/spark/spark/deployment.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: spark-master
   labels:
-    fateModule: spark-master
+    fateMoudle: spark-master
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: {{ default 1 .Values.modules.spark.master.replicas }}
@@ -23,12 +23,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: spark-master
+      fateMoudle: spark-master
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: spark-master
+        fateMoudle: spark-master
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:
@@ -103,7 +103,7 @@ kind: Deployment
 metadata:
   name: spark-worker
   labels:
-    fateModule: spark-worker
+    fateMoudle: spark-worker
 {{ include "fate.labels" . | indent 4 }}
 spec:
   replicas: {{ default 2 .Values.modules.spark.worker.replicas }}
@@ -111,12 +111,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      fateModule: spark-worker
+      fateMoudle: spark-worker
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: spark-worker
+        fateMoudle: spark-worker
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:

--- a/helm-charts/FATE/templates/backends/spark/spark/ingress.yaml
+++ b/helm-charts/FATE/templates/backends/spark/spark/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: spark
   labels:
-    fateModule: spark
+    fateMoudle: spark
 {{ include "fate.labels" . | indent 4 }}
 {{- if .Values.ingress.spark.annotations }}
   annotations:

--- a/helm-charts/FATE/templates/backends/spark/spark/service.yaml
+++ b/helm-charts/FATE/templates/backends/spark/spark/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: spark-master
   labels:
-    fateModule: spark-master
+    fateMoudle: spark-master
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -34,7 +34,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   selector:
-    fateModule: spark-master
+    fateMoudle: spark-master
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 apiVersion: v1
@@ -42,7 +42,7 @@ kind: Service
 metadata:
   name: spark-client
   labels:
-    fateModule: spark-master
+    fateMoudle: spark-master
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -64,7 +64,7 @@ spec:
   type: {{ .Values.modules.spark.master.type }}
   # clusterIP: None
   selector:
-    fateModule: spark-master
+    fateMoudle: spark-master
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 apiVersion: v1
@@ -72,7 +72,7 @@ kind: Service
 metadata:
   name: spark-worker-1
   labels:
-    fateModule: spark-worker
+    fateMoudle: spark-worker
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -83,7 +83,7 @@ spec:
   type: {{ .Values.modules.spark.worker.type }}
   clusterIP: None
   selector:
-    fateModule: spark-worker
+    fateMoudle: spark-worker
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{ end }}

--- a/helm-charts/FATE/templates/core/client/ingress.yaml
+++ b/helm-charts/FATE/templates/core/client/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: client
   labels:
-    fateModule: client
+    fateMoudle: client
 {{ include "fate.labels" . | indent 4 }}
   {{- if .Values.ingress.client.annotations }}
   annotations:

--- a/helm-charts/FATE/templates/core/client/service.yaml
+++ b/helm-charts/FATE/templates/core/client/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: notebook
   labels:
-    fateModule: client
+    fateMoudle: client
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -25,6 +25,6 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.client.type }}
   selector:
-    fateModule: client
+    fateMoudle: client
 {{ include "fate.matchLabels" . | indent 4 }}
 {{- end }}

--- a/helm-charts/FATE/templates/core/client/statefulSet.yaml
+++ b/helm-charts/FATE/templates/core/client/statefulSet.yaml
@@ -15,19 +15,19 @@ kind: StatefulSet
 metadata:
   name: client
   labels:
-    fateModule: client
+    fateMoudle: client
 {{ include "fate.labels" . | indent 4 }}
 spec:
   serviceName: notebook
   replicas: 1
   selector:
     matchLabels:
-      fateModule: client
+      fateMoudle: client
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: client
+        fateMoudle: client
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:
@@ -113,7 +113,7 @@ spec:
     - metadata:
         name: persistence
         labels:
-          fateModule: client
+          fateMoudle: client
 {{ include "fate.labels" . | indent 10 }}
       spec:
         accessModes: [{{ .Values.modules.client.accessMode | quote }}]

--- a/helm-charts/FATE/templates/core/fateboard/configmap.yaml
+++ b/helm-charts/FATE/templates/core/fateboard/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: fateboard-config
   labels:
-    fateModule: fateboard
+    fateMoudle: fateboard
 {{ include "fate.labels" . | indent 4 }}
 data:
   application.properties: |

--- a/helm-charts/FATE/templates/core/fateboard/ingress.yaml
+++ b/helm-charts/FATE/templates/core/fateboard/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: fateboard
   labels:
-    fateModule: fateboard
+    fateMoudle: fateboard
 {{ include "fate.labels" . | indent 4 }}
 {{- if .Values.ingress.fateboard.annotations }}
   annotations:

--- a/helm-charts/FATE/templates/core/fateboard/service.yaml
+++ b/helm-charts/FATE/templates/core/fateboard/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: fateboard
   labels:
-    fateModule: python
+    fateMoudle: python
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -25,6 +25,6 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.fateboard.type }}
   selector:
-    fateModule: python
+    fateMoudle: python
 {{ include "fate.matchLabels" . | indent 4 }}
 {{- end }}

--- a/helm-charts/FATE/templates/core/fateflow/configmap.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 metadata:
   name: python-config
   labels:
-    fateModule: python
+    fateMoudle: python
 {{ include "fate.labels" . | indent 4 }}
 data:
   spark-defaults.conf: |
@@ -255,7 +255,7 @@ apiVersion: v1
 metadata:
   name: pulsar-route-table
   labels:
-    fateModule: python
+    fateMoudle: python
 {{ include "fate.labels" . | indent 4 }}
 data:
   pulsar_route_table.yaml: |
@@ -282,7 +282,7 @@ apiVersion: v1
 metadata:
   name: rabbitmq-route-table
   labels:
-    fateModule: python
+    fateMoudle: python
 {{ include "fate.labels" . | indent 4 }}
 data:
   rabbitmq_route_table.yaml: |

--- a/helm-charts/FATE/templates/core/fateflow/service.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: fateflow
   labels:
-    fateModule: fateflow
+    fateMoudle: fateflow
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -30,7 +30,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   selector:
-    fateModule: python
+    fateMoudle: python
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 apiVersion: v1
@@ -38,7 +38,7 @@ kind: Service
 metadata:
   name: fateflow-client
   labels:
-    fateModule: fateflow
+    fateMoudle: fateflow
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -63,7 +63,7 @@ spec:
   {{- end }}
   
   selector:
-    fateModule: python
+    fateMoudle: python
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{- if and .Values.modules.python.spark.portMaxRetries (ne (print .Values.modules.python.spark.driverHost) "fateflow") }}
@@ -72,7 +72,7 @@ kind: Service
 metadata:
   name: fateflow-sparkdriver
   labels:
-    fateModule: python
+    fateMoudle: python
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -95,7 +95,7 @@ spec:
     {{- end }}
   type: {{ .Values.modules.python.spark.driverHostType }}
   selector:
-    fateModule: python
+    fateMoudle: python
 {{ include "fate.matchLabels" . | indent 4 }}
 ---
 {{- end }}

--- a/helm-charts/FATE/templates/core/mysql/configmap.yaml
+++ b/helm-charts/FATE/templates/core/mysql/configmap.yaml
@@ -15,7 +15,7 @@ kind: ConfigMap
 metadata:
   name: mysql-config
   labels:
-    fateModule: mysql
+    fateMoudle: mysql
 {{ include "fate.labels" . | indent 4 }}
 data:
   {{- if eq .Values.modules.python.backend  "spark" }}

--- a/helm-charts/FATE/templates/core/mysql/service.yaml
+++ b/helm-charts/FATE/templates/core/mysql/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: mysql
   labels:
-    fateModule: mysql
+    fateMoudle: mysql
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -25,6 +25,6 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.mysql.type }}
   selector:
-    fateModule: mysql
+    fateMoudle: mysql
 {{ include "fate.matchLabels" . | indent 4 }}
 {{ end }}

--- a/helm-charts/FATE/templates/core/mysql/statefulSet.yaml
+++ b/helm-charts/FATE/templates/core/mysql/statefulSet.yaml
@@ -15,19 +15,19 @@ kind: StatefulSet
 metadata:
   name: mysql
   labels:
-    fateModule: mysql
+    fateMoudle: mysql
 {{ include "fate.labels" . | indent 4 }}
 spec:
   serviceName: mysql
   replicas: 1
   selector:
     matchLabels:
-      fateModule: mysql
+      fateMoudle: mysql
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: mysql
+        fateMoudle: mysql
 {{ include "fate.labels" . | indent 8 }}
     spec:
       containers:
@@ -111,13 +111,13 @@ spec:
         {{- else if and .Values.persistence.enabled (.Values.modules.mysql.existingClaim) }}
         - name: data
           persistentVolumeClaim:
-            claimName: {{ .Values.modules.mysql.existingClaim | default  "mysql-data" }}\
+            claimName: {{ .Values.modules.mysql.existingClaim | default  "mysql-data" }}
         {{- else }}
   volumeClaimTemplates:
     - metadata:
         name: data
         labels:
-          fateModule: mysql
+          fateMoudle: mysql
 {{ include "fate.labels" . | indent 10 }}
       spec:
         accessModes: [{{ .Values.modules.mysql.accessMode | quote }}]

--- a/helm-charts/FATE/templates/core/python-spark.yaml
+++ b/helm-charts/FATE/templates/core/python-spark.yaml
@@ -15,19 +15,19 @@ kind: StatefulSet
 metadata:
   name: python
   labels:
-    fateModule: python
+    fateMoudle: python
 {{ include "fate.labels" . | indent 4 }}
 spec:
   serviceName: fateflow
   replicas: 1
   selector:
     matchLabels:
-      fateModule: python
+      fateMoudle: python
 {{ include "fate.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        fateModule: python
+        fateMoudle: python
 {{ include "fate.labels" . | indent 8 }}
     spec:
       {{- if .Values.istio.enabled }}
@@ -283,7 +283,7 @@ spec:
     - metadata:
         name: python-data
         labels:
-          fateModule: python
+          fateMoudle: python
 {{ include "fate.labels" . | indent 10 }}
       spec:
         accessModes: [{{ .Values.modules.python.accessMode | quote }}]

--- a/helm-charts/FATE/templates/psp.yaml
+++ b/helm-charts/FATE/templates/psp.yaml
@@ -14,7 +14,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:
-    fateModule: psp
+    fateMoudle: psp
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 spec:

--- a/helm-charts/FATE/templates/role.yaml
+++ b/helm-charts/FATE/templates/role.yaml
@@ -14,7 +14,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    fateModule: role
+    fateMoudle: role
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 rules:

--- a/helm-charts/FATE/templates/rolebinding.yaml
+++ b/helm-charts/FATE/templates/rolebinding.yaml
@@ -14,7 +14,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    fateModule: serviceAccount
+    fateMoudle: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 roleRef:

--- a/helm-charts/FATE/templates/serviceaccount.yaml
+++ b/helm-charts/FATE/templates/serviceaccount.yaml
@@ -14,7 +14,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    fateModule: serviceAccount
+    fateMoudle: serviceAccount
 {{ include "fate.labels" . | indent 4 }}
   name: {{ .Values.partyName }}
 {{- end }}

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -365,7 +365,7 @@ backend: eggroll
     # 9999:
       # host: pulsar
       # port: 6650
-      # sslPort:6651
+      # sslPort: 6651
     # 10000:
       # host: 192.168.10.1
       # port: 30105


### PR DESCRIPTION
## Description

1. Basically, this change is to revert https://github.com/FederatedAI/KubeFATE/pull/680/files# 
2. Changed the value-template-example.yaml, add a space,  because it will cause the yaml validator to raise a false alarm.
3. Remove an accidentally added slash in
  helm-charts/FATE/templates/core/mysql/statefulSet.yaml 

## Test
After change, I can successfully upgrade my 1.8.0 fate cluster to 1.9.0
Also, there is no false alarm from the cluster.yaml validator