### PR TITLE
Fix the issue that we failed to stop upgrading from v1.7.1

### DIFF
--- a/k8s-deploy/pkg/job/fate_upgrade_manager.go
+++ b/k8s-deploy/pkg/job/fate_upgrade_manager.go
@@ -69,7 +69,7 @@ func (fum *FateUpgradeManager) validate(specOld, specNew modules.MapStringInterf
 	}
 
 	// KubeFATE cannot support rolling upgrade for FATE version <= 1.7.1
-	if newVersion == oldVersion {
+	if newVersion != oldVersion {
 		ver171, _ := version.NewVersion("1.7.1")
 		if oldVerFormatted.LessThanOrEqual(ver171) {
 			return errors.New("upgrade from FATE version <= 1.7.1 is not supported by KubeFATE")

--- a/k8s-deploy/pkg/job/fate_upgrade_manager_test.go
+++ b/k8s-deploy/pkg/job/fate_upgrade_manager_test.go
@@ -23,12 +23,12 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-	ogSpecOld := modules.MapStringInterface{
+	specOld := modules.MapStringInterface{
 		"chartName":    "fate",
 		"chartVersion": "v1.7.2",
 		"imageTag":     "1.7.2-release",
 	}
-	ogSpecNew := modules.MapStringInterface{
+	specNew := modules.MapStringInterface{
 		"chartName":    "fate",
 		"chartVersion": "v1.8.0",
 		"imageTag":     "1.8.0-release",
@@ -37,8 +37,6 @@ func TestValidate(t *testing.T) {
 		namespace: "blabla",
 	}
 	// Happy path
-	specOld := ogSpecOld
-	specNew := ogSpecNew
 	err := fum.validate(specOld, specNew)
 	assert.Nil(t, err)
 
@@ -46,32 +44,33 @@ func TestValidate(t *testing.T) {
 	specNew["chartName"] = "openfl"
 	err = fum.validate(specOld, specNew)
 	assert.NotNil(t, err)
+	specNew["chartName"] = "fate"
 
 	// spec identical
-	specNew = ogSpecNew
 	specNew["chartVersion"] = "v1.7.2"
 	specNew["imageTag"] = "1.7.2-release"
 	err = fum.validate(specOld, specNew)
 	assert.NotNil(t, err)
+	specNew["chartVersion"] = "v1.8.0"
+	specNew["imageTag"] = "1.8.0-release"
 
 	// image version do not consistent with the chart version
-	specNew = ogSpecNew
 	specNew["imageTag"] = "1.9.0-release"
 	err = fum.validate(specOld, specNew)
 	assert.NotNil(t, err)
+	specNew["imageTag"] = "1.8.0-release"
 
 	// do not support downgrade
-	specNew = ogSpecNew
 	specNew["chartVersion"] = "v1.6.0"
 	specNew["imageTag"] = "1.6.0-release"
 	err = fum.validate(specOld, specNew)
 	assert.NotNil(t, err)
+	specNew["chartVersion"] = "v1.8.0"
+	specNew["imageTag"] = "1.8.0-release"
 
 	// fate version < 1.7.1
-	specNew = ogSpecNew
-	specOld = ogSpecOld
 	specOld["chartVersion"] = "v1.7.0"
-	specNew["imageTag"] = "1.7.0-release"
+	specOld["imageTag"] = "1.7.0-release"
 	err = fum.validate(specOld, specNew)
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

## Description
We plan to stop upgrading from verison < 1.7.2, because the issue of the mysql version of the helm chart.
However, when I do the test to upgrade from 1.7.1 to 1.8.0, I make it, and finally meet the issue of mysql downgrade.

The root cause is that I added a wrong logic in the validator.

The RCCA for this issue is,  the UT is not good. I thought in golang assignment is deep copy, but actually it is just another alias.

## Test
New UT passed, add temporary log to verify that the err message is exptected.
Verify that using kubefate to upgrade a FATE cluster from v1.7.1 cannot be done now.

```
(venv) ➜  k8s-deploy git:(fix-issue) ✗ kfcu 18-9999.yaml 
upgrade from FATE version <= 1.7.1 is not supported by KubeFATE

```