### PR TITLE
[1/3] Support TLS for eggroll: p2p mode

### DIFF
--- a/docs/Eggroll_with_TLS.md
+++ b/docs/Eggroll_with_TLS.md
@@ -1,0 +1,101 @@
+# Eggroll with TLS
+
+Since KubeFATE release v1.9.0, we can leverage KubeFATE to deploy eggroll-based FATE clusters who communicate with each other by TLS.
+
+## Generate certificates
+Preparations:
+
+In a place where you can access your K8s cluster, run
+```bash
+mkdir my-ca
+cd my-ca
+wget https://raw.githubusercontent.com/apache/pulsar/master/tests/certificate-authority/openssl.cnf
+export CA_HOME=$(pwd)
+mkdir certs crl newcerts private
+chmod 700 private/
+touch index.txt
+echo 1000 > serial
+```
+Generate the private key of the root cert
+```bash
+openssl genrsa -aes256 -out private/ca.key.pem 4096
+chmod 400 private/ca.key.pem
+```
+private/ca.key.pem is a key you should not share with anyone.
+
+Then generate the root certification using the private key:
+```bash
+openssl req -config openssl.cnf -key private/ca.key.pem \
+    -new -x509 -days 7300 -sha256 -extensions v3_ca \
+    -out certs/ca.cert.pem
+chmod 444 certs/ca.cert.pem
+```
+When it prompts the requirement of the common name, you need to come up with one. In this example we use:
+```
+example.com
+```
+This root certificate is also the CA certificate, once it has been created, you can create certificate requests and sign them with this CA, with above common name as the suffix.
+
+For one rollsite, we need 2 pairs of certifications and private keys, one pair for acting as a client and another one pair for acting as a server.
+
+Suppose a site is called party-9999.
+
+For client:
+
+Generate the private key for the rollsite party:
+```bash
+mkdir fate-9999
+openssl genrsa -out fate-9999/client_priv.key 2048
+```
+Generate the certificate request with the private key:
+```
+openssl req -config openssl.cnf -key fate-9999/client.key -new -sha256 -out fate-9999/client.csr
+```
+When it prompts the request common name, you can type in something like ```party-9999-client.example.com```.
+
+Generate the client certification for rollsite party-9999:
+```
+openssl ca -config openssl.cnf -days 10000 -notext -md sha256 -in fate-9999/client.csr -out fate-9999/client.crt
+```
+
+For server:
+
+The steps are similar, example:
+```bash
+openssl genrsa -out fate-9999/server_priv.key 2048
+openssl pkcs8 -topk8 -inform PEM -in fate-9999/server_priv.key -outform PEM -out fate-9999/server.key -nocrypt
+openssl req -config openssl.cnf -key fate-9999/server_priv.key -new -sha256 -out fate-9999/server.csr
+```
+Type ```party-9999-server.example.com``` as the common name.
+```bash
+openssl ca -config openssl.cnf -days 10000 -extensions server_cert -notext -md sha256 -in fate-9999/server.csr -out fate-9999/server.crt
+```
+The last step is to create a K8s secret based on the generated files:
+```bash
+kubectl -n fate-9999 create secret generic eggroll-certs \
+  --from-file=ca.pem=certs/ca.cert.pem \
+  --from-file=client.key=fate-9999/client.key \
+  --from-file=client.crt=fate-9999/client.crt \
+  --from-file=server.key=fate-9999/server.key \
+  --from-file=server.crt=fate-9999/server.crt 
+```
+
+## Enable TLS for rollsite in cluster.yaml file
+
+Enable this switch under the rollsite module.
+```yaml
+rollsite: 
+  enableTLS: true
+```
+
+## P2P mode
+
+In this mode, a FATE cluster's rollsite will communicate with the rollsite of another FATE cluster.
+
+So we need to:
+1. Generate the certs files for each party
+2. Create the secrets for each party
+3. Turn on "enableTLS" for each party's rollsite
+
+## Exchange mode
+TODO

--- a/docs/FATE_On_Spark_With_Pulsar.md
+++ b/docs/FATE_On_Spark_With_Pulsar.md
@@ -125,7 +125,7 @@ Enter the following command to create a directory for the CA, and put the openss
 ``` bash
 $ mkdir my-ca
 $ cd my-ca
-$ wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+$ wget https://raw.githubusercontent.com/apache/pulsar/master/tests/certificate-authority/openssl.cnf
 $ export CA_HOME=$(pwd)
 ```
 

--- a/helm-charts/FATE/templates/backends/eggroll/configmap.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/configmap.yaml
@@ -83,7 +83,6 @@ data:
     eggroll.rollsite.push.long.retry=2
     eggroll.rollsite.push.batches.per.stream=10
     eggroll.rollsite.adapter.sendbuf.size=100000
-    
     # polling
     # {{ .Values.modules.rollsite.polling.enabled }}
     # {{ .Values.modules.rollsite.polling.type }}
@@ -96,4 +95,15 @@ data:
     eggroll.rollsite.polling.server.enabled=true
     eggroll.rollsite.polling.concurrency= {{ .Values.modules.rollsite.polling.concurrency | default 50 }}
     {{- end }}
+  {{- if .Values.modules.rollsite.enableTLS }}
+  cert_configs: |
+    eggroll.core.security.secure.cluster.enabled=true
+    eggroll.core.security.secure.client.auth.enabled=true
+    eggroll.core.security.ca.crt.path=conf/cert/ca.pem
+    eggroll.core.security.crt.path=conf/cert/server.crt
+    eggroll.core.security.key.path=conf/cert/server.key
+    eggroll.core.security.client.ca.crt.path=conf/cert/ca.pem
+    eggroll.core.security.client.crt.path=conf/cert/client.crt
+    eggroll.core.security.client.key.path=conf/cert/client.key
+  {{- end }}
 {{ end }}

--- a/helm-charts/FATE/templates/backends/eggroll/rollsite/deployment.yaml
+++ b/helm-charts/FATE/templates/backends/eggroll/rollsite/deployment.yaml
@@ -59,8 +59,12 @@ spec:
             ln -sf /dev/stdout /data/projects/fate/eggroll/logs/eggroll/eggroll-audit.log
             touch /data/projects/fate/eggroll/logs/eggroll/eggroll.jvm.log
             ln -sf /dev/stdout /data/projects/fate/eggroll/logs/eggroll/eggroll.jvm.log
-            touch /data/projects/fate/eggroll/logs/eggroll/eggroll.jvm.err.log 
+            touch /data/projects/fate/eggroll/logs/eggroll/eggroll.jvm.err.log
             ln -sf /dev/stderr /data/projects/fate/eggroll/logs/eggroll/eggroll.jvm.err.log
+            cp /data/projects/fate/eggroll/conf/temp_eggroll.properties /data/projects/fate/eggroll/conf/eggroll.properties
+            {{- if .Values.modules.rollsite.enableTLS }}
+            cat /data/projects/fate/eggroll/conf/cert_configs >> /data/projects/fate/eggroll/conf/eggroll.properties
+            {{- end}}
             java -Dlog4j.configurationFile=$${EGGROLL_HOME}/conf/log4j2.properties -cp $${EGGROLL_HOME}/lib/*:$${EGGROLL_HOME}/conf/ com.webank.eggroll.rollsite.EggSiteBootstrap -c $${EGGROLL_HOME}/conf/eggroll.properties
           ports:
             - containerPort: 9370
@@ -88,9 +92,16 @@ spec:
           volumeMounts:
             - mountPath: /data/projects/fate/eggroll/conf/route_table/
               name: rollsite-confs
-            - mountPath: /data/projects/fate/eggroll/conf/eggroll.properties
+            - mountPath: /data/projects/fate/eggroll/conf/temp_eggroll.properties
               name: eggroll-confs
               subPath: eggroll.properties
+            {{- if .Values.modules.rollsite.enableTLS }}
+            - mountPath: /data/projects/fate/eggroll/conf/cert_configs
+              name: eggroll-confs
+              subPath: cert_configs
+            - mountPath: /data/projects/fate/eggroll/conf/cert/
+              name: eggroll-certs
+            {{- end }}
       {{- with .Values.modules.rollsite.nodeSelector }}
       nodeSelector: 
 {{ toYaml . | indent 8 }}
@@ -116,4 +127,9 @@ spec:
         - name: eggroll-confs
           configMap:
             name: eggroll-config
+        {{- if .Values.modules.rollsite.enableTLS }}
+        - name: eggroll-certs
+          secret:
+            secretName: eggroll-certs
+        {{- end}}
 {{ end }}

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -65,6 +65,7 @@ backend: eggroll
   # - partyId: 10000
     # partyIp: 192.168.0.1
     # partyPort: 30101
+  # enableTLS: true
   # nodeSelector:
   # - disktype: ssd
   # tolerations:

--- a/helm-charts/FATE/values-template.yaml
+++ b/helm-charts/FATE/values-template.yaml
@@ -147,6 +147,7 @@ modules:
     type: {{ .type | default "ClusterIP" }}
     nodePort: {{ .nodePort }}
     loadBalancerIP: {{ .loadBalancerIP }}
+    enableTLS: {{ .enableTLS | default false}}
     {{- with .nodeSelector }}
     nodeSelector: 
 {{ toYaml . | indent 6 }}
@@ -283,7 +284,8 @@ modules:
     {{- with .clustermanager }}
     ip: clustermanager
     type: "ClusterIP"
-    {{- with .nodeSelector }}
+    enableTLS: {{ .enableTLS | default false }}
+  {{- with .nodeSelector }}
     nodeSelector: 
 {{ toYaml . | indent 6 }}
     {{- end }}

--- a/helm-charts/FATE/values.yaml
+++ b/helm-charts/FATE/values.yaml
@@ -79,7 +79,8 @@ modules:
     ip: rollsite
     type: ClusterIP
     nodePort: 30091
-    loadBalancerIP: 
+    loadBalancerIP:
+    enableTLS: false
     nodeSelector:
     tolerations:
     affinity:


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

Fixes  #588 

## Description
The motivation can be seen on #588 

The reason why I create cert_configs under the configmap eggroll-config, instead of adding the things into the eggroll.properties is beacause:

1. The eggroll.properties is mounted by clustermanager, nodemanager and the rollsite.
2. If we add the TLS related configs into eggroll.properties directly, nodemanager and clustermanager will crash.
3. Actually nodemanager and clustermanager don't need to be enabled TLS, only rollsite need.

Also fixed a 404 link in the pulsar doc.

## Test
After enablement of TLS, verified it works in the log of rollsite's pod:
```
[INFO ][2564][2022-08-02 06:31:44,234][main,pid:1,tid:1][c.w.e.c.t.GrpcServerUtils:107] - gRPC server at port=9380 starting in secure mode. server private key path: /data/projects/fate/eggroll/conf/cert/server.key, key crt path: /data/projects/fate/eggroll/conf/cert/server.crt, ca crt path: /data/projects/fate/eggroll/conf/cert/ca.pem
[INFO ][2568][2022-08-02 06:31:44,238][main,pid:1,tid:1][c.w.e.r.EggSiteBootstrap:107] - secure server started at 9380
```
Upload data and training succeed:
![Screen Shot 2022-08-02 at 14 50 59](https://user-images.githubusercontent.com/15973672/182396723-b2499a7a-f2ae-4236-b9b9-c3c547e89c51.png)



