### PR TITLE
[2/3][3/3] Support TLS for eggroll: exchange mode and docker-compose

### DIFF
--- a/docs/Eggroll_with_TLS.md
+++ b/docs/Eggroll_with_TLS.md
@@ -42,10 +42,11 @@ Suppose a site is called party-9999.
 
 For client:
 
-Generate the private key for the rollsite party:
+Generate the private key for the rollsite party, because rollsite doesn't support RSA formatted private key, we need to change to format to pkcs8.
 ```bash
 mkdir fate-9999
-openssl genrsa -out fate-9999/client_priv.key 2048
+openssl genrsa -out fate-9999/client.key 2048
+openssl pkcs8 -topk8 -inform PEM -in fate-9999/client.key -outform PEM -out fate-9999/client.key -nocrypt
 ```
 Generate the certificate request with the private key:
 ```
@@ -62,9 +63,9 @@ For server:
 
 The steps are similar, example:
 ```bash
-openssl genrsa -out fate-9999/server_priv.key 2048
-openssl pkcs8 -topk8 -inform PEM -in fate-9999/server_priv.key -outform PEM -out fate-9999/server.key -nocrypt
-openssl req -config openssl.cnf -key fate-9999/server_priv.key -new -sha256 -out fate-9999/server.csr
+openssl genrsa -out fate-9999/server.key 2048
+openssl pkcs8 -topk8 -inform PEM -in fate-9999/server.key -outform PEM -out fate-9999/server.key -nocrypt
+openssl req -config openssl.cnf -key fate-9999/server.key -new -sha256 -out fate-9999/server.csr
 ```
 Type ```party-9999-server.example.com``` as the common name.
 ```bash
@@ -94,8 +95,84 @@ In this mode, a FATE cluster's rollsite will communicate with the rollsite of an
 
 So we need to:
 1. Generate the certs files for each party
-2. Create the secrets for each party
+2. Create the K8s secrets for each party, in the corresponding K8s namespace
 3. Turn on "enableTLS" for each party's rollsite
 
 ## Exchange mode
-TODO
+In this mode, every FATE cluster's rollsite will talk to the rollsite of the FATE-Exchange.
+
+So we need to:
+1. Generate the certs files for each party, and the FATE exchange
+2. Create the K8s secrets for each party, in the corresponding K8s namespace
+3. Turn on "enableTLS" for each party's rollsite, and also the exchange's rollsite
+
+An example of the steps for exchange:
+
+For client cert:
+```bash
+mkdir fate-exchange
+
+openssl genrsa -out fate-exchange/client.key 2048
+openssl pkcs8 -topk8 -inform PEM -in fate-9999/client.key -outform PEM -out fate-exchange/client.key -nocrypt
+openssl req -config openssl.cnf -key fate-exchange/client.key -new -sha256 -out fate-exchange/client.csr
+```
+Type in for example, ```exchange-client.example.com``` as the common name.
+```bash
+openssl ca -config openssl.cnf -days 10000 -notext -md sha256 -in fate-exchange/client.csr -out fate-exchange/client.crt
+```
+
+For server cert:
+```bash
+openssl genrsa -out fate-exchange/server.key 2048
+openssl pkcs8 -topk8 -inform PEM -in fate-9999/server.key -outform PEM -out fate-exchange/server.key -nocrypt
+openssl req -config openssl.cnf -key fate-exchange/server.key -new -sha256 -out fate-exchange/server.csr
+```
+Type in for example, ```exchange-server.example.com``` as the common name.
+```bash
+openssl ca -config openssl.cnf -days 10000 -extensions server_cert -notext -md sha256 -in fate-exchange/server.csr -out fate-exchange/server.crt
+```
+
+Create K8s secret:
+```bash
+kubectl -n fate-exchange create secret generic eggroll-certs \
+  --from-file=ca.pem=certs/ca.cert.pem \
+  --from-file=client.key=fate-exchange/client.key \
+  --from-file=client.crt=fate-exchange/client.crt \
+  --from-file=server.key=fate-exchange/server.key \
+  --from-file=server.crt=fate-exchange/server.crt 
+```
+
+Then in the cluster.yaml file of FATE-Exchange, turn on the ```enableTLS``` switch under the rollsite module.
+
+## Docker-Compose mode
+
+In KubeFATE release v1.9.0, we will not provide a switch for enabling TLS for rollsite. This can be done in below manual steps:
+
+1. Generate the certs, as above documents shows, for every FATE cluster and for the FATE Exchange if needed.
+2. Run `docker ps` to get the container id of the rollsite.
+3. Run `docker exec -it <rollsite-container-id> bash` to get into the rollsite container.
+4. In dir `/data/projects/fate/eggroll/conf`, run `mkdir cert`.
+5. Edit 5 files: `ca.pem client.crt client.key server.crt server.key`, input the contents of the certifications and the private keys you have generated. `ca.pem` is the CA's certification, we assume you use this certification to sign both the client certification and the server certification of rollsite.
+6. In dir `/data/projects/fate/eggroll/conf`, edit `eggroll.properties`, tail below contents:
+    ```
+    eggroll.core.security.secure.cluster.enabled=true
+    eggroll.core.security.secure.client.auth.enabled=true
+    eggroll.core.security.ca.crt.path=conf/cert/ca.pem
+    eggroll.core.security.crt.path=conf/cert/server.crt
+    eggroll.core.security.key.path=conf/cert/server.key
+    eggroll.core.security.client.ca.crt.path=conf/cert/ca.pem
+    eggroll.core.security.client.crt.path=conf/cert/client.crt
+    eggroll.core.security.client.key.path=conf/cert/client.key
+    ```
+7. Run `docker restart <rollsite-container-id>`
+
+After above steps, your eggroll deployed on Docker Compose should start to communicate with each other by TLS.
+
+One way to verify that is to check the log of the rollsite container by `docker logs <rollsite-container-id>`, if you see logs like:
+
+```
+[INFO ][2046][2022-08-03 06:41:48,543][main,pid:1,tid:1][c.w.e.c.t.GrpcServerUtils:107] - gRPC server at port=9380 starting in secure mode. server private key path: /data/projects/fate/eggroll/conf/cert/server.key, key crt path: /data/projects/fate/eggroll/conf/cert/server.crt, ca crt path: /data/projects/fate/eggroll/conf/cert/ca.pem
+[INFO ][2051][2022-08-03 06:41:48,548][main,pid:1,tid:1][c.w.e.r.EggSiteBootstrap:107] - secure server started at 9380
+```
+
+Then it indicates that you have enabled TLS on rollsite successfully on Docker Compose.

--- a/docs/Introduction_to_Backend_Architecture.md
+++ b/docs/Introduction_to_Backend_Architecture.md
@@ -25,7 +25,7 @@ Modify the `parties.conf` configuration when using docker-compose:
 backend=eggroll
 ```
 
-Modify the `parties.conf` configuration when using Kubernetes:
+Modify the `cluster.yaml` configuration when using Kubernetes:
 
 ```yaml
 backend: eggroll
@@ -36,6 +36,8 @@ Architecture diagram:
 <div align="center">
   <img src="./images/arch_eggroll.png" />
 </div>
+
+To enabled TLS for the eggroll backend between different FATE parties, check this [doc](/docs/Eggroll_with_TLS.md).
 
 ### spark_rabbitmq
 
@@ -49,7 +51,7 @@ Modify the `parties.conf` configuration when using docker-compose:
 backend=spark_rabbitmq
 ```
 
-Modify the `parties.conf` configuration when using Kubernetes:
+Modify the `cluster.yaml` configuration when using Kubernetes:
 
 ```yaml
 backend: spark_rabbitmq
@@ -73,7 +75,7 @@ Modify the `parties.conf` configuration when using docker-compose:
 backend=spark_pulsar
 ```
 
-Modify the `parties.conf` configuration when using Kubernetes:
+Modify the `cluster.yaml` configuration when using Kubernetes:
 
 ```yaml
 backend: spark_pulsar
@@ -97,7 +99,7 @@ Modify the `parties.conf` configuration when using docker-compose:
 backend=spark_local_pulsar
 ```
 
-Modify the `parties.conf` configuration when using Kubernetes:
+Modify the `cluster.yaml` configuration when using Kubernetes:
 
 ```yaml
 backend: spark_local_pulsar

--- a/helm-charts/FATE-Exchange/templates/rollsite-module.yaml
+++ b/helm-charts/FATE-Exchange/templates/rollsite-module.yaml
@@ -34,6 +34,17 @@ data:
     eggroll.rollsite.push.batches.per.stream=10
     eggroll.rollsite.adapter.sendbuf.size=100000
 
+    {{- if .Values.modules.rollsite.enableTLS }}
+    eggroll.core.security.secure.cluster.enabled=true
+    eggroll.core.security.secure.client.auth.enabled=true
+    eggroll.core.security.ca.crt.path=conf/cert/ca.pem
+    eggroll.core.security.crt.path=conf/cert/server.crt
+    eggroll.core.security.key.path=conf/cert/server.key
+    eggroll.core.security.client.ca.crt.path=conf/cert/ca.pem
+    eggroll.core.security.client.crt.path=conf/cert/client.crt
+    eggroll.core.security.client.key.path=conf/cert/client.key
+    {{- end }}
+
   route_table.json: |
     {
         "route_table": {
@@ -133,6 +144,10 @@ spec:
             - mountPath: /data/projects/fate/eggroll/conf/eggroll.properties
               name: rollsite-confs
               subPath: eggroll.properties
+            {{- if .Values.modules.rollsite.enableTLS }}
+            - mountPath: /data/projects/fate/eggroll/conf/cert/
+              name: eggroll-certs
+            {{- end }}
       {{- with .Values.modules.rollsite.nodeSelector }}
       nodeSelector: 
 {{ toYaml . | indent 8 }}
@@ -155,6 +170,11 @@ spec:
         - name: rollsite-confs
           configMap:
             name: rollsite-config
+        {{- if .Values.modules.rollsite.enableTLS }}
+        - name: eggroll-certs
+          secret:
+            secretName: eggroll-certs
+        {{- end}}
 ---
 apiVersion: v1
 kind: Service

--- a/helm-charts/FATE-Exchange/values-template-example.yaml
+++ b/helm-charts/FATE-Exchange/values-template-example.yaml
@@ -22,6 +22,7 @@ rollsite:
   type: NodePort
   nodePort: 30001
   loadBalancerIP: 192.168.0.1
+  enableTLS: false
   partyList:
   - partyId: 10000
     partyIp: 192.168.10.1

--- a/helm-charts/FATE-Exchange/values-template.yaml
+++ b/helm-charts/FATE-Exchange/values-template.yaml
@@ -50,6 +50,7 @@ modules:
 {{ toYaml . | indent 6 }}
     {{- end }}
     type: {{ .type }}
+    enableTLS: {{ .enableTLS | default false }}
     nodePort: {{ .nodePort }}
     partyList:
     {{- range .partyList }}

--- a/helm-charts/FATE-Exchange/values.yaml
+++ b/helm-charts/FATE-Exchange/values.yaml
@@ -29,7 +29,8 @@ modules:
     ip: rollsite
     type: ClusterIP
     nodePort: 30001
-    loadBalancerIP: 
+    loadBalancerIP:
+    enableTLS: false
     nodeSelector:
     tolerations:
     affinity:

--- a/k8s-deploy/examples/party-exchange/rollsite.yaml
+++ b/k8s-deploy/examples/party-exchange/rollsite.yaml
@@ -1,7 +1,7 @@
 name: fate-exchange
 namespace: fate-exchange
 chartName: fate-exchange
-chartVersion: 
+chartVersion: v1.8.0
 partyId: 1
 registry: ""
 imageTag: 1.8.0-release
@@ -19,6 +19,7 @@ modules:
 rollsite: 
   type: NodePort
   nodePort: 30000
+  enableTLS: false
   partyList:
   - partyId: 10000
     partyIp: 192.168.10.1

--- a/k8s-deploy/pkg/cli/cluster_cli.go
+++ b/k8s-deploy/pkg/cli/cluster_cli.go
@@ -154,15 +154,14 @@ func ClusterInstallCommand() *cli.Command {
 			}
 
 			chartVersion, ok := m["chartVersion"]
-			if !ok {
-				return errors.New("chartVersion not found, check your Cluster file")
+			if !ok || chartVersion == "" {
+				return errors.New("chartVersion not found, check your cluster.yaml file")
 			}
 
 			chartName, ok := m["chartName"]
-			if !ok {
-				chartName = ""
+			if !ok || chartName == "" {
+				return errors.New("chartName not found, check your cluster.yaml file")
 			}
-
 			if template, err := GetValueTemplateExample(chartName.(string), chartVersion.(string)); err != nil {
 				if _, ok := err.(VersionNotValidError); !ok {
 					// if the error is not VersionNotValidError, warn user.


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

Fixes  #588 

## Description

1. For exchange, we add a swtich to enable TLS for eggroll,  the certifications need to be managed by the user, we provide the document.
2. For docker-compose, we provide the document to illustrate how to enable it, the certifications need to be managed by the user, and the use need to do mote manual steps to enable TLS.
3. Add some protection logic in the cli code.


## TEST

### Exchange on K8s

Enabled FATE Exchange, and let two parties to communicate with the exchange's rollsite.
Enable TLS for each FATE cluster and the exchange cluster.
Verified that we can upload data, train a model and do a prediction successfully:

![Screen Shot 2022-08-03 at 15 35 17](https://user-images.githubusercontent.com/15973672/182556654-75a384b7-264f-43a0-b26f-c0b797e2e817.png)


### docker-compose

Following the newly added doc in ths PR, verified that the rollsite on Docker Compose is communicating with each other  by the log:

```
01:40:19 root@sc1-10-182-137-144 docker-deploy ±|develop-1-9-0 ✗|→ docker logs 3d7800ba229f
current dir: /data/projects/fate/eggroll/.
...
[INFO ][2534][2022-08-03 05:29:36,772][main,pid:8,tid:1][c.w.e.c.t.GrpcServerUtils:107] - gRPC server at port=9380 starting in secure mode. server private key path: /data/projects/fate/eggroll/conf/cert/server.key, key crt path: /data/projects/fate/eggroll/conf/cert/server.crt, ca crt path: /data/projects/fate/eggroll/conf/cert/ca.pem
[INFO ][2537][2022-08-03 05:29:36,775][main,pid:8,tid:1][c.w.e.r.EggSiteBootstrap:107] - secure server started at 9380
```

The test passed:
```
01:30:32 root@sc1-10-182-137-144 docker-deploy ±|develop-1-9-0 ✗|→ bash test.sh toy_example 9999 10000
start test toy_example
......
toy test job 202208030130453615700 is success
[INFO] [2022-08-03 01:30:57,442] [202208030130453615700] [447:140661993834304] - [secure_add_guest.run] [line:96]: begin to init parameters of secure add example guest
[INFO] [2022-08-03 01:30:57,443] [202208030130453615700] [447:140661993834304] - [secure_add_guest.run] [line:100]: begin to make guest data
[INFO] [2022-08-03 01:30:57,574] [202208030130453615700] [447:140661993834304] - [secure_add_guest.run] [line:103]: split data into two random parts
[INFO] [2022-08-03 01:30:59,652] [202208030130453615700] [447:140661993834304] - [secure_add_guest.run] [line:106]: share one random part data to host
[INFO] [2022-08-03 01:30:59,660] [202208030130453615700] [447:140661993834304] - [secure_add_guest.run] [line:109]: get share of one random part data from host
[INFO] [2022-08-03 01:31:02,908] [202208030130453615700] [447:140661993834304] - [secure_add_guest.run] [line:112]: begin to get sum of guest and host
[INFO] [2022-08-03 01:31:03,070] [202208030130453615700] [447:140661993834304] - [secure_add_guest.run] [line:115]: receive host sum from guest
[INFO] [2022-08-03 01:31:03,253] [202208030130453615700] [447:140661993834304] - [secure_add_guest.run] [line:122]: success to calculate secure_sum, it is 2000.0000000000
```

