### PR TITLE
unify the authorization requirement on swagger

### DIFF
--- a/k8s-deploy/docs/docs.go
+++ b/k8s-deploy/docs/docs.go
@@ -40,6 +40,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -105,6 +106,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -175,6 +177,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -243,6 +246,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -309,6 +313,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -385,6 +390,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -462,6 +468,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -541,6 +548,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -615,6 +623,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -678,6 +687,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -745,6 +755,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -821,6 +832,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -889,6 +901,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -999,6 +1012,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1118,6 +1132,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1169,6 +1184,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1232,6 +1248,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1305,6 +1322,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1375,6 +1393,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1477,6 +1496,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1523,6 +1543,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1591,6 +1612,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1656,6 +1678,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1898,6 +1921,9 @@ const docTemplate = `{
         "modules.ClusterArgs": {
             "type": "object",
             "properties": {
+                "Keep_upgrade_job": {
+                    "type": "boolean"
+                },
                 "chart_name": {
                     "type": "string"
                 },

--- a/k8s-deploy/docs/swagger.json
+++ b/k8s-deploy/docs/swagger.json
@@ -32,6 +32,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -97,6 +98,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -167,6 +169,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -235,6 +238,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -301,6 +305,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -377,6 +382,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -454,6 +460,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -533,6 +540,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -607,6 +615,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -670,6 +679,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -737,6 +747,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -813,6 +824,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -881,6 +893,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -991,6 +1004,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1110,6 +1124,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1161,6 +1176,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1224,6 +1240,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1297,6 +1314,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1367,6 +1385,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1469,6 +1488,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1515,6 +1535,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1583,6 +1604,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1648,6 +1670,7 @@
                     },
                     {
                         "type": "string",
+                        "default": "Bearer \u003cToken\u003e",
                         "description": "Authentication header",
                         "name": "Authorization",
                         "in": "header",
@@ -1890,6 +1913,9 @@
         "modules.ClusterArgs": {
             "type": "object",
             "properties": {
+                "Keep_upgrade_job": {
+                    "type": "boolean"
+                },
                 "chart_name": {
                     "type": "string"
                 },

--- a/k8s-deploy/docs/swagger.yaml
+++ b/k8s-deploy/docs/swagger.yaml
@@ -113,6 +113,8 @@ definitions:
     type: object
   modules.ClusterArgs:
     properties:
+      Keep_upgrade_job:
+        type: boolean
       chart_name:
         type: string
       chart_version:
@@ -264,7 +266,8 @@ paths:
   /chart:
     get:
       parameters:
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -303,7 +306,8 @@ paths:
         name: file
         required: true
         type: file
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -345,7 +349,8 @@ paths:
         name: chartId
         required: true
         type: string
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -381,7 +386,8 @@ paths:
         name: chartId
         required: true
         type: string
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -424,7 +430,8 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/modules.ClusterArgs'
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -469,7 +476,8 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/modules.ClusterArgs'
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -515,7 +523,8 @@ paths:
         name: all
         required: true
         type: boolean
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -562,7 +571,8 @@ paths:
         name: clusterId
         required: true
         type: string
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -606,7 +616,8 @@ paths:
         name: clusterId
         required: true
         type: string
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -646,7 +657,8 @@ paths:
   /job/:
     get:
       parameters:
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -686,7 +698,8 @@ paths:
         name: jobId
         required: true
         type: string
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -722,7 +735,8 @@ paths:
         name: jobId
         required: true
         type: string
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -769,7 +783,8 @@ paths:
         name: jobStatus
         required: true
         type: string
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -850,7 +865,8 @@ paths:
         name: limit-bytes
         required: true
         type: string
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -927,7 +943,8 @@ paths:
         name: limit-bytes
         required: true
         type: string
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -959,7 +976,8 @@ paths:
   /namespace/:
     get:
       parameters:
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -996,7 +1014,8 @@ paths:
   /user:
     get:
       parameters:
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -1040,7 +1059,8 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/modules.User'
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -1082,7 +1102,8 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/modules.User'
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -1124,7 +1145,8 @@ paths:
         name: userId
         required: true
         type: string
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -1160,7 +1182,8 @@ paths:
         name: userId
         required: true
         type: string
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -1222,7 +1245,8 @@ paths:
   /user/logout:
     post:
       parameters:
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true
@@ -1256,7 +1280,8 @@ paths:
         name: chartVersion
         required: true
         type: string
-      - description: Authentication header
+      - default: Bearer <Token>
+        description: Authentication header
         in: header
         name: Authorization
         required: true

--- a/k8s-deploy/pkg/api/chart.go
+++ b/k8s-deploy/pkg/api/chart.go
@@ -58,7 +58,7 @@ type HelmUUID struct {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /valueTemplateExample/{chartName}/{chartVersion} [get]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*Chart) getValueTemplateExample(c *gin.Context) {
 	name, version := c.Param("chartName"), c.Param("chartVersion")
@@ -89,7 +89,7 @@ func (*Chart) getValueTemplateExample(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /chart [post]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*Chart) createChart(c *gin.Context) {
 	// single file
@@ -142,7 +142,7 @@ func (*Chart) createChart(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /chart [get]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*Chart) getChartList(c *gin.Context) {
 
@@ -166,7 +166,7 @@ func (*Chart) getChartList(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /chart/{chartId} [get]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*Chart) getChart(c *gin.Context) {
 
@@ -198,7 +198,7 @@ func (*Chart) getChart(c *gin.Context) {
 // @Failure 401 {object} JSONEMSGResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /chart/{chartId} [delete]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*Chart) deleteChart(c *gin.Context) {
 	chartID := c.Param("chartId")

--- a/k8s-deploy/pkg/api/cluster.go
+++ b/k8s-deploy/pkg/api/cluster.go
@@ -54,7 +54,7 @@ func (c *Cluster) Router(r *gin.RouterGroup) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /cluster [post]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 // @Security OAuth2Application[write, admin]
 func (*Cluster) createCluster(c *gin.Context) {
@@ -91,7 +91,7 @@ func (*Cluster) createCluster(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /cluster [put]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 // @Security OAuth2Application[write, admin]
 func (*Cluster) setCluster(c *gin.Context) {
@@ -134,7 +134,7 @@ func (*Cluster) setCluster(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /cluster/{clusterId} [get]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 // @Security OAuth2Application[write, admin]
 func (*Cluster) getCluster(c *gin.Context) {
@@ -202,7 +202,7 @@ func (*Cluster) getCluster(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /cluster/ [get]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 // @Security OAuth2Application[write, admin]
 func (*Cluster) getClusterList(c *gin.Context) {
@@ -236,7 +236,7 @@ func (*Cluster) getClusterList(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /cluster/{clusterId} [delete]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 // @Security OAuth2Application[write, admin]
 func (*Cluster) deleteCluster(c *gin.Context) {

--- a/k8s-deploy/pkg/api/job.go
+++ b/k8s-deploy/pkg/api/job.go
@@ -50,7 +50,7 @@ func (j *Job) Router(r *gin.RouterGroup) {
 // @Failure 400 {object} JSONERRORResult "Bad Request"
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Router /job/ [get]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*Job) getJobList(c *gin.Context) {
 
@@ -74,7 +74,7 @@ func (*Job) getJobList(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /job/{jobId} [get]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*Job) getJob(c *gin.Context) {
 
@@ -106,7 +106,7 @@ func (*Job) getJob(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /job/{jobId} [put]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*Job) putJob(c *gin.Context) {
 
@@ -143,7 +143,7 @@ func (*Job) putJob(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /job/{jobId} [delete]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*Job) deleteJob(c *gin.Context) {
 

--- a/k8s-deploy/pkg/api/kube_log.go
+++ b/k8s-deploy/pkg/api/kube_log.go
@@ -70,7 +70,7 @@ func (e *kubeLog) Router(r *gin.RouterGroup) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /log/{clusterID} [get]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*kubeLog) getClusterLog(c *gin.Context) {
 
@@ -138,7 +138,7 @@ func (*kubeLog) getClusterLog(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /log/{clusterID}/ws [get]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*kubeLog) getClusterLogWs(c *gin.Context) {
 

--- a/k8s-deploy/pkg/api/namespace.go
+++ b/k8s-deploy/pkg/api/namespace.go
@@ -45,7 +45,7 @@ func (j *Namespace) Router(r *gin.RouterGroup) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /namespace/ [get]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*Namespace) getNamespaceList(c *gin.Context) {
 

--- a/k8s-deploy/pkg/api/user.go
+++ b/k8s-deploy/pkg/api/user.go
@@ -75,7 +75,7 @@ func (authMiddleware *authMiddleware) login(c *gin.Context) {
 // @Success 200 {object} string
 // @Failure 401 {object} JSONEMSGResult
 // @Router /user/logout [post]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (authMiddleware *authMiddleware) logout(c *gin.Context) {
 	authMiddleware.LogoutHandler(c)
@@ -116,7 +116,7 @@ func generateAdminUser() error {
 // @Failure 401 {object} JSONERRORResult Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /user [post]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*User) createUser(c *gin.Context) {
 
@@ -153,7 +153,7 @@ func (*User) createUser(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /user [put]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*User) setUser(c *gin.Context) {
 
@@ -184,7 +184,7 @@ func (*User) setUser(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /user/{userId} [get]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*User) getUser(c *gin.Context) {
 
@@ -211,7 +211,7 @@ func (*User) getUser(c *gin.Context) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /user [get]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*User) getUserList(c *gin.Context) {
 
@@ -241,7 +241,7 @@ func getUserFindByUUID(uuid string) (modules.User, error) {
 // @Failure 401 {object} JSONERRORResult "Unauthorized operation"
 // @Failure 500 {object} JSONERRORResult "Internal server error"
 // @Router /user/{userId} [delete]
-// @Param Authorization header string true "Authentication header"
+// @Param Authorization header string true "Authentication header" default(Bearer <Token>)
 // @Security ApiKeyAuth
 func (*User) deleteUser(c *gin.Context) {
 


### PR DESCRIPTION
Signed-off-by: hang lv <xlv20@fudan.edu.cn>

Fixes  ISSUE#699

Changes:

1. Modify the swagger to unify the authorization requirement of KubeFATE APIs.

