### PR TITLE
Fix chart format

### DIFF
--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -28,16 +28,19 @@ modules:
   # - nginx
   # - rabbitmq
 
-# Computing : Eggroll, Spark, Spark_local
+# Computing : [Eggroll, Spark, Spark_local]
 computing: Eggroll
-# Federation: Eggroll(computing: Eggroll), Pulsar/RabbitMQ(computing: Spark/Spark_local)
+# Federation: [Eggroll(computing: Eggroll), Pulsar/RabbitMQ(computing: Spark/Spark_local)]
 federation: Eggroll
-# Storage: Eggroll(computing: Eggroll), HDFS(computing: Spark), LocalFS(computing: Spark_local)
+# Storage: [Eggroll(computing: Eggroll), HDFS(computing: Spark), LocalFS(computing: Spark_local)]
 storage: Eggroll
-# Algorithm: Basic, NN
+# Algorithm: [Basic, NN]
 algorithm: Basic
-# Device: IPCL, CPU
+# Device: [IPCL, CPU]
 device: IPCL
+
+skippedKeys:
+  - route_table
 
 # ingress:
   # fateboard:

--- a/k8s-deploy/examples/party-10000/cluster.yaml
+++ b/k8s-deploy/examples/party-10000/cluster.yaml
@@ -29,6 +29,10 @@ storage: Eggroll
 algorithm: Basic
 device: CPU
 
+# you can customize some keys which will be ignored in yaml validation
+skippedKeys:
+  - route_table
+
 ingress:
   fateboard: 
     hosts:

--- a/k8s-deploy/examples/party-9999/cluster.yaml
+++ b/k8s-deploy/examples/party-9999/cluster.yaml
@@ -29,6 +29,10 @@ storage: Eggroll
 algorithm: Basic
 device: CPU
 
+# you can customize some keys which will be ignored in yaml validation
+skippedKeys:
+  - route_table
+
 ingress:
   fateboard:
     hosts:


### PR DESCRIPTION
Fixes  ISSUE#xxx

Changes:

1. modified `values-template-example.yaml` to satisfy yaml format when comments trimmed to prevent YAML to JSON errors.
2. add skippedKeys into  `values-template-example.yaml`  and `example/party-xxxx/cluster.yaml`  to tell user how to skip the validation of some keys. So no name of route_table redundant errors show up.

before
```
Config Warning: error converting YAML to JSON: yaml: line 33: mapping values are not allowed in this context
```
and 
```
Config Warning: your yaml at '/pulsar/route_table/9991', line 370 
  '9991:' may be redundant
Config Warning: your yaml at '/pulsar/route_table/9991', line 374 
  '10010:' may be redundant
```
after
```
```


