### PR TITLE
Update error messages when listing namespaces or getting node ip fails with admin role in particular namespace.

### DIFF
--- a/docs/Deploy_FATE_Cluster_with_Admin_Role_in_Certain_Namespace.md
+++ b/docs/Deploy_FATE_Cluster_with_Admin_Role_in_Certain_Namespace.md
@@ -134,7 +134,7 @@ When installing multiple KubeFATE services in one K8s cluster, the domains shoul
 
 There will be some limits when user only has admin privilege in certain namespace:
 
-1. Some commands of KubeFATE won't work:
-   - `kubefate namespace ls`
-   - `kubefate cluster describe`
+1. Some commands of KubeFATE won't work smoothly:
+   - `kubefate namespace ls`(cannot get namespaces)
+   - `kubefate cluster describe`(cannot get node ip)
 2. PodSecurityPolicy can not be enabled.

--- a/k8s-deploy/pkg/service/info.go
+++ b/k8s-deploy/pkg/service/info.go
@@ -22,7 +22,7 @@ func GetClusterInfo(name, namespace string) (map[string]interface{}, error) {
 	ip, err := GetNodeIP()
 	if err != nil {
 		log.Error().Str("func", "GetNodeIP()").Err(err).Msg("GetNodeIP error")
-		return nil, err
+		ip = []string{err.Error()}
 	}
 	port, err := GetProxySvcNodePorts(name, getDefaultNamespace(namespace))
 	if err != nil {

--- a/k8s-deploy/pkg/service/kube_namespace.go
+++ b/k8s-deploy/pkg/service/kube_namespace.go
@@ -24,7 +24,7 @@ import (
 func GetNamespaces() ([]v1.Namespace, error) {
 	namespaceList, err := KubeClient.GetNamespaces()
 	if err != nil {
-		return nil, errors.New("Get namespaces failed. Please check if user has the privilege to list resource \"namespaces\" at the cluster scope")
+		return nil, errors.Wrap(err, "Get namespaces failed. Please check if user has the privilege to list resource \"namespaces\" at the cluster scope")
 	}
 	return namespaceList.Items, nil
 }

--- a/k8s-deploy/pkg/service/kube_namespace.go
+++ b/k8s-deploy/pkg/service/kube_namespace.go
@@ -16,6 +16,7 @@
 package service
 
 import (
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -23,7 +24,7 @@ import (
 func GetNamespaces() ([]v1.Namespace, error) {
 	namespaceList, err := KubeClient.GetNamespaces()
 	if err != nil {
-		return nil, err
+		return nil, errors.New("Get namespaces failed. Please check if user has the privilege to list resource \"namespaces\" at the cluster scope")
 	}
 	return namespaceList.Items, nil
 }

--- a/k8s-deploy/pkg/service/kube_node.go
+++ b/k8s-deploy/pkg/service/kube_node.go
@@ -15,12 +15,14 @@
 
 package service
 
+import "github.com/pkg/errors"
+
 // GetNodeIP get a node ip
 func GetNodeIP() ([]string, error) {
 
 	svcs, err := KubeClient.GetNodes("")
 	if err != nil {
-		return nil, err
+		return nil, errors.New("Get node ip failed. Please check if user has the privilege to list resource \"nodes\" at the cluster scope")
 	}
 
 	var nodeIP []string

--- a/k8s-deploy/pkg/service/kube_node.go
+++ b/k8s-deploy/pkg/service/kube_node.go
@@ -22,7 +22,7 @@ func GetNodeIP() ([]string, error) {
 
 	svcs, err := KubeClient.GetNodes("")
 	if err != nil {
-		return nil, errors.New("Get node ip failed. Please check if user has the privilege to list resource \"nodes\" at the cluster scope")
+		return nil, errors.Wrap(err, "Get node ip failed. Please check if user has the privilege to list resource \"nodes\" at the cluster scope")
 	}
 
 	var nodeIP []string


### PR DESCRIPTION
Fixes ISSUE #708 

## Description
1. When deploy KubeFATE and FATE clusters with admin role in particular namespace, kubefate commands may fail and produce ugly message. So this PR optimizes the error message of listing namespaces failure.
2. In the case above, the command describing a cluster won't work because admin role doesn't have the privilege to get node ip at cluster scope. So this PR changes default logic when getting node ip fails to ensure the command output info as usual except for node ip.

## Tests
### Before fix
```sh
$ kubefate namespace ls
namespaces is forbidden: User "system:serviceaccount:fate-9999:kubefate-admin" cannot list resource "namespaces" in API group "" at the cluster scope
 
$ kubefate cluster describe 1b7e1690-72f5-4c60-9251-57a930cab5ab
nodes is forbidden: User "system:serviceaccount:fate-9999:kubefate-admin" cannot list resource "nodes" in API group "" at the cluster scope
```
### After fix
```sh
$ kubefate namespace ls
Get namespaces failed. Please check if user has the privilege to list resource "namespaces" at the cluster scope: namespaces is forbidden: User "system:serviceaccount:fate-10000:kubefate-admin" cannot list resource "namespaces" in API group "" at the cluster scope

$ kubefate cluster describe 1b7e1690-72f5-4c60-9251-57a930cab5ab
UUID        	1b7e1690-72f5-4c60-9251-57a930cab5ab
...
Info        	dashboard:                                                                             
            	...                                                    
            	ip: Get node ip failed. Please check if user has the privilege to list resource "nodes"
            	  at the cluster scope: nodes is forbidden: User                                               
            	"system:serviceaccount:fate-10000:kubefate-admin"                                              
            	  cannot list resource "nodes" in API group "" at the cluster scope'   
            	...      
```