### PR TITLE
remove imageTag checks & leave it to  default configured in values.yaml

### DIFF
--- a/build/ci/ansible/roles/kubefate/files/kubefate-e2e/common.sh
+++ b/build/ci/ansible/roles/kubefate/files/kubefate-e2e/common.sh
@@ -126,16 +126,7 @@ set_cluster_image() {
         sed -i "s#registry: .*#registry: ${DOCKER_REGISTRY}#g" cluster-spark.yaml
         sed -i "s#registry: .*#registry: ${DOCKER_REGISTRY}#g" cluster-serving.yaml
     fi
-    if [[ $FATE_VERSION != "" ]]; then
-        sed -i "s#imageTag: .*#imageTag: ${FATE_VERSION}#g" cluster.yaml
-        sed -i "s#imageTag: .*#imageTag: ${FATE_VERSION}#g" cluster-spark.yaml
-    fi
-    if [[ $FATE_VERSION != "" ]]; then
-        sed -i "s#imageTag: .*#imageTag: ${FATE_SERVING_VERSION}#g" cluster-serving.yaml
-    fi
     logdebug "REGISTRY=${DOCKER_REGISTRY}"
-    logdebug "FATE_IMG_TAG=${FATE_VERSION}"
-    logdebug "FATE_SERVING_IMG_TAG=${fate_serving_version}"
 }
 
 jobUUID=""

--- a/docs/FATE_Upgrade.md
+++ b/docs/FATE_Upgrade.md
@@ -68,7 +68,6 @@ chartName: fate
 chartVersion: v1.7.2
 partyId: 9999
 registry: ""
-imageTag: 1.7.2-release
 pullPolicy:
 imagePullSecrets:
    - name: myregistrykey
@@ -210,10 +209,9 @@ snapshot.sql
 ```
 
 ### Using KubeFATE CLI to do the upgrade
-We just need to change two lines of the cluster.yaml file:
+We just need to change `chartVersion` in  the cluster.yaml file:
 ```
 chartVersion: v1.7.2	  ->   chartVersion: v1.8.0
-imageTag: 1.7.2-release   ->   imageTag: 1.8.0-release
 ```
 Then execute:
 ```

--- a/docs/Pulsar_Exchange.md
+++ b/docs/Pulsar_Exchange.md
@@ -10,7 +10,6 @@ chartName: fate-exchange
 chartVersion: v1.6.0
 partyId: 1
 registry: ""
-imageTag: "1.6.0-release"
 pullPolicy: 
 imagePullSecrets: 
 - name: myregistrykey

--- a/docs/configurations/FATE_Exchange_cluster_configuration.md
+++ b/docs/configurations/FATE_Exchange_cluster_configuration.md
@@ -10,7 +10,6 @@
 | chartVersion              | scalars   | FATE chart corresponding version.                                                                       |
 | partyId                   | scalars   | FATE-Exchange cluster party id.                                                                         |
 | registry                  | scalars   | Other fate images sources.                                                                              |
-| imageTag                  | scalars   | Image TAG                                                                                               |
 | pullPolicy                | scalars   | Kubernetes images pull policy.                                                                          |
 | persistence               | bool      | Redis and servingServer data persistence.                                                               |
 | podSecurityPolicy.enabled | bool      | if `true`, create & use Pod Security Policy resources                                                   |

--- a/docs/tutorials/Build_Two_Parties_FATE_Cluster_in_One_Linux_Machine_with_MiniKube.md
+++ b/docs/tutorials/Build_Two_Parties_FATE_Cluster_in_One_Linux_Machine_with_MiniKube.md
@@ -237,7 +237,6 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 9999
 registry: "hub.c.163.com/federatedai"
-imageTag: "1.8.0-release"
 pullPolicy:
 imagePullSecrets:
 - name: myregistrykey
@@ -291,7 +290,6 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 10000
 registry: "hub.c.163.com/federatedai"
-imageTag: "1.8.0-release"
 pullPolicy:
 imagePullSecrets:
 - name: myregistrykey

--- a/docs/tutorials/Build_Two_Parties_FATE_Cluster_in_One_Linux_Machine_with_MiniKube_zh.md
+++ b/docs/tutorials/Build_Two_Parties_FATE_Cluster_in_One_Linux_Machine_with_MiniKube_zh.md
@@ -217,7 +217,6 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 9999
 registry: "hub.c.163.com/federatedai"
-imageTag: "1.8.0-release"
 pullPolicy:
 imagePullSecrets:
 - name: myregistrykey
@@ -272,7 +271,6 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 10000
 registry: "hub.c.163.com/federatedai"
-imageTag: "1.8.0-release"
 pullPolicy:
 imagePullSecrets:
 - name: myregistrykey

--- a/helm-charts/FATE-Exchange/values-template-example.yaml
+++ b/helm-charts/FATE-Exchange/values-template-example.yaml
@@ -4,8 +4,7 @@ chartName: fate-exchange
 chartVersion: v1.8.0
 partyId: 1
 registry: ""
-imageTag: "1.8.0-release"
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/helm-charts/FATE-Exchange/values-template.yaml
+++ b/helm-charts/FATE-Exchange/values-template.yaml
@@ -4,7 +4,6 @@ partyName: {{ .name }}
 image:
   registry: {{ .registry | default "federatedai" }}
   isThridParty: {{ empty .registry | ternary  "false" "true" }}
-  tag: {{ .imageTag | default "1.8.0-release" }}
   pullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
   {{- with .imagePullSecrets }}
   imagePullSecrets:

--- a/helm-charts/FATE-Serving/values-template-example.yaml
+++ b/helm-charts/FATE-Serving/values-template-example.yaml
@@ -4,8 +4,7 @@ chartName: fate-serving
 chartVersion: v2.1.6
 partyId: 10000
 registry: ""
-imageTag: "2.1.6-release"
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/helm-charts/FATE-Serving/values-template.yaml
+++ b/helm-charts/FATE-Serving/values-template.yaml
@@ -6,7 +6,6 @@ partyName: {{ .name }}
 image:
   registry: {{ .registry | default "federatedai" }}
   isThridParty: {{ empty .registry | ternary  "false" "true" }}
-  tag: {{ .imageTag | default "2.1.6-release" }}
   pullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
   {{- with .imagePullSecrets }}
   imagePullSecrets:

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -4,7 +4,6 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 9999
 registry: ""
-imageTag: "1.8.0-release"
 pullPolicy: 
 imagePullSecrets: 
 - name: myregistrykey

--- a/helm-charts/FATE/values-template.yaml
+++ b/helm-charts/FATE/values-template.yaml
@@ -2,7 +2,6 @@
 image:
   registry: {{ .registry | default "federatedai" }}
   isThridParty: {{ empty .registry | ternary  "false" "true" }}
-  tag: {{ .imageTag | default "1.8.0-release" }}
   pullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
   {{- with .imagePullSecrets }}
   imagePullSecrets:

--- a/k8s-deploy/cluster-serving.yaml
+++ b/k8s-deploy/cluster-serving.yaml
@@ -4,8 +4,7 @@ chartName: fate-serving
 chartVersion: v2.1.6
 partyId: 9999
 registry: ""
-imageTag: "2.1.6-release"
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/cluster-spark-pulsar.yaml
+++ b/k8s-deploy/cluster-spark-pulsar.yaml
@@ -4,8 +4,7 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 9999
 registry: ""
-imageTag: "1.8.0-release"
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/cluster-spark-rabbitmq.yaml
+++ b/k8s-deploy/cluster-spark-rabbitmq.yaml
@@ -4,8 +4,7 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 9999
 registry: ""
-imageTag: "1.8.0-release"
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/cluster-spark-slim.yaml
+++ b/k8s-deploy/cluster-spark-slim.yaml
@@ -4,8 +4,7 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 9999
 registry: ""
-imageTag: "1.8.0-release"
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/cluster.yaml
+++ b/k8s-deploy/cluster.yaml
@@ -4,8 +4,7 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 9999
 registry: ""
-imageTag: "1.8.0-release"
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/examples/config.sh
+++ b/k8s-deploy/examples/config.sh
@@ -3,9 +3,7 @@
 source party.config
 
 echo "FATE chartVersion: "${fate_chartVersion}
-echo "FATE imageTAG: "${fate_imageTAG}
 echo "FATE-Serving chartVersion: "${fate_serving_chartVersion}
-echo "FATE-Serving_imageTAG: "${fate_serving_imageTAG}
 echo "Party 9999 IP: "${party_9999_IP}
 echo "Party 10000 IP: "${party_10000_IP}
 echo "Party exchange IP: "${party_exchange_IP}
@@ -26,12 +24,6 @@ $SED -i "s/chartVersion: .*/chartVersion: ${fate_serving_chartVersion}/g" ./part
 $SED -i "s/chartVersion: .*/chartVersion: ${fate_chartVersion}/g" ./party-9999/cluster-spark-rabbitmq.yaml
 $SED -i "s/chartVersion: .*/chartVersion: ${fate_chartVersion}/g" ./party-9999/cluster-spark-pulsar.yaml
 $SED -i "s/chartVersion: .*/chartVersion: ${fate_chartVersion}/g" ./party-9999/cluster-spark-local-pulsar.yaml
-
-$SED -i "s/imageTag: .*/imageTag: ${fate_imageTAG}/g" ./party-9999/cluster.yaml
-$SED -i "s/imageTag: .*/imageTag: ${fate_serving_imageTAG}/g" ./party-9999/cluster-serving.yaml
-$SED -i "s/imageTag: .*/imageTag: ${fate_imageTAG}/g" ./party-9999/cluster-spark-rabbitmq.yaml
-$SED -i "s/imageTag: .*/imageTag: ${fate_imageTAG}/g" ./party-9999/cluster-spark-pulsar.yaml
-$SED -i "s/imageTag: .*/imageTag: ${fate_imageTAG}/g" ./party-9999/cluster-spark-local-pulsar.yaml
 
 $SED -i "s/192.168.9.1/${party_9999_IP}/g" ./party-9999/cluster.yaml
 $SED -i "s/192.168.9.1/${party_9999_IP}/g" ./party-9999/cluster-serving.yaml
@@ -66,12 +58,6 @@ $SED -i "s/chartVersion: .*/chartVersion: ${fate_chartVersion}/g" ./party-10000/
 $SED -i "s/chartVersion: .*/chartVersion: ${fate_chartVersion}/g" ./party-10000/cluster-spark-pulsar.yaml
 $SED -i "s/chartVersion: .*/chartVersion: ${fate_chartVersion}/g" ./party-10000/cluster-spark-local-pulsar.yaml
 
-$SED -i "s/imageTag: .*/imageTag: ${fate_imageTAG}/g" ./party-10000/cluster.yaml
-$SED -i "s/imageTag: .*/imageTag: ${fate_serving_imageTAG}/g" ./party-10000/cluster-serving.yaml
-$SED -i "s/imageTag: .*/imageTag: ${fate_imageTAG}/g" ./party-10000/cluster-spark-rabbitmq.yaml
-$SED -i "s/imageTag: .*/imageTag: ${fate_imageTAG}/g" ./party-10000/cluster-spark-pulsar.yaml
-$SED -i "s/imageTag: .*/imageTag: ${fate_imageTAG}/g" ./party-10000/cluster-spark-local-pulsar.yaml
-
 $SED -i "s/192.168.9.1/${party_9999_IP}/g" ./party-10000/cluster.yaml
 $SED -i "s/192.168.9.1/${party_9999_IP}/g" ./party-10000/cluster-serving.yaml
 $SED -i "s/192.168.9.1/${party_9999_IP}/g" ./party-10000/cluster-spark-rabbitmq.yaml
@@ -100,9 +86,6 @@ done
 
 $SED -i "s/chartVersion: .*/chartVersion: ${chartVersion}/g" ./party-exchange/rollsite.yaml
 $SED -i "s/chartVersion: .*/chartVersion: ${chartVersion}/g" ./party-exchange/trafficServer.yaml
-
-$SED -i "s/imageTag: .*/imageTag: ${fate_imageTAG}/g" ./party-exchange/rollsite.yaml
-$SED -i "s/imageTag: .*/imageTag: ${fate_imageTAG}/g" ./party-exchange/trafficServer.yaml
 
 $SED -i "s/192.168.9.1/${party_9999_IP}/g" ./party-exchange/rollsite.yaml
 $SED -i "s/192.168.9.1/${party_9999_IP}/g" ./party-exchange/trafficServer.yaml

--- a/k8s-deploy/examples/party-10000/cluster-serving.yaml
+++ b/k8s-deploy/examples/party-10000/cluster-serving.yaml
@@ -4,8 +4,7 @@ chartName: fate-serving
 chartVersion: v2.1.6
 partyId: 10000
 registry: ""
-imageTag: 2.1.6-release
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/examples/party-10000/cluster-spark-local-pulsar.yaml
+++ b/k8s-deploy/examples/party-10000/cluster-spark-local-pulsar.yaml
@@ -4,8 +4,7 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 10000
 registry: ""
-imageTag: 1.8.0-release
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/examples/party-10000/cluster-spark-pulsar.yaml
+++ b/k8s-deploy/examples/party-10000/cluster-spark-pulsar.yaml
@@ -4,8 +4,7 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 10000
 registry: ""
-imageTag: 1.8.0-release
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/examples/party-10000/cluster-spark-rabbitmq.yaml
+++ b/k8s-deploy/examples/party-10000/cluster-spark-rabbitmq.yaml
@@ -4,8 +4,7 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 10000
 registry: ""
-imageTag: 1.8.0-release
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/examples/party-10000/cluster.yaml
+++ b/k8s-deploy/examples/party-10000/cluster.yaml
@@ -4,8 +4,7 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 10000
 registry: ""
-imageTag: 1.8.0-release
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/examples/party-9999/cluster-serving.yaml
+++ b/k8s-deploy/examples/party-9999/cluster-serving.yaml
@@ -4,8 +4,7 @@ chartName: fate-serving
 chartVersion: v2.1.6
 partyId: 9999
 registry: ""
-imageTag: 2.1.6-release
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/examples/party-9999/cluster-spark-local-pulsar.yaml
+++ b/k8s-deploy/examples/party-9999/cluster-spark-local-pulsar.yaml
@@ -4,8 +4,7 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 9999
 registry: ""
-imageTag: 1.8.0-release
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/examples/party-9999/cluster-spark-pulsar.yaml
+++ b/k8s-deploy/examples/party-9999/cluster-spark-pulsar.yaml
@@ -4,8 +4,7 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 9999
 registry: ""
-imageTag: 1.8.0-release
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/examples/party-9999/cluster-spark-rabbitmq.yaml
+++ b/k8s-deploy/examples/party-9999/cluster-spark-rabbitmq.yaml
@@ -4,8 +4,7 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 9999
 registry: ""
-imageTag: 1.8.0-release
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/examples/party-9999/cluster.yaml
+++ b/k8s-deploy/examples/party-9999/cluster.yaml
@@ -4,8 +4,7 @@ chartName: fate
 chartVersion: v1.8.0
 partyId: 9999
 registry: ""
-imageTag: 1.8.0-release
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/examples/party-exchange/rollsite.yaml
+++ b/k8s-deploy/examples/party-exchange/rollsite.yaml
@@ -4,8 +4,7 @@ chartName: fate-exchange
 chartVersion: v1.8.0
 partyId: 1
 registry: ""
-imageTag: 1.8.0-release
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/examples/party-exchange/trafficServer.yaml
+++ b/k8s-deploy/examples/party-exchange/trafficServer.yaml
@@ -4,8 +4,7 @@ chartName: fate-exchange
 chartVersion: 
 partyId: 1
 registry: ""
-imageTag: 1.8.0-release
-pullPolicy: 
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/pkg/job/cluster_install.go
+++ b/k8s-deploy/pkg/job/cluster_install.go
@@ -18,7 +18,6 @@ package job
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/FederatedAI/KubeFATE/k8s-deploy/pkg/modules"
@@ -218,12 +217,6 @@ func createCluster(job *modules.Job) (*modules.Cluster, error) {
 	if err != nil {
 		log.Error().Err(err).Interface("clusterArgs", job.Metadata).Msg("NewCluster")
 		return nil, err
-	}
-
-	if cluster.ChartName == fateChartName {
-		if !strings.Contains(cluster.Spec["imageTag"].(string), strings.ReplaceAll(cluster.ChartVersion, "v", "")) {
-			return nil, errors.New("the image tag is inconsistent with the chart version, which is unsupported")
-		}
 	}
 
 	// Save Cluster to database

--- a/k8s-deploy/pkg/job/fate_upgrade_manager.go
+++ b/k8s-deploy/pkg/job/fate_upgrade_manager.go
@@ -53,14 +53,6 @@ func (fum *FateUpgradeManager) validate(specOld, specNew modules.MapStringInterf
 		return errors.New("the configuration file did not change")
 	}
 
-	// The image version should be consistent with the chartVersion
-	newVersion = strings.ReplaceAll(newVersion, "v", "")
-	oldVersion = strings.ReplaceAll(oldVersion, "v", "")
-	newImgVersion := specNew["imageTag"].(string)
-	if !strings.Contains(newImgVersion, newVersion) {
-		return errors.New("the image tag is inconsistent with the chart version, which is unsupported")
-	}
-
 	// Do not support downgrade
 	newVerFormatted, _ := version.NewVersion(newVersion)
 	oldVerFormatted, _ := version.NewVersion(oldVersion)

--- a/k8s-deploy/pkg/job/fate_upgrade_manager_test.go
+++ b/k8s-deploy/pkg/job/fate_upgrade_manager_test.go
@@ -26,12 +26,10 @@ func TestValidate(t *testing.T) {
 	specOld := modules.MapStringInterface{
 		"chartName":    "fate",
 		"chartVersion": "v1.7.2",
-		"imageTag":     "1.7.2-release",
 	}
 	specNew := modules.MapStringInterface{
 		"chartName":    "fate",
 		"chartVersion": "v1.8.0",
-		"imageTag":     "1.8.0-release",
 	}
 	fum := FateUpgradeManager{
 		namespace: "blabla",
@@ -48,29 +46,18 @@ func TestValidate(t *testing.T) {
 
 	// spec identical
 	specNew["chartVersion"] = "v1.7.2"
-	specNew["imageTag"] = "1.7.2-release"
 	err = fum.validate(specOld, specNew)
 	assert.NotNil(t, err)
 	specNew["chartVersion"] = "v1.8.0"
-	specNew["imageTag"] = "1.8.0-release"
-
-	// image version do not consistent with the chart version
-	specNew["imageTag"] = "1.9.0-release"
-	err = fum.validate(specOld, specNew)
-	assert.NotNil(t, err)
-	specNew["imageTag"] = "1.8.0-release"
 
 	// do not support downgrade
 	specNew["chartVersion"] = "v1.6.0"
-	specNew["imageTag"] = "1.6.0-release"
 	err = fum.validate(specOld, specNew)
 	assert.NotNil(t, err)
 	specNew["chartVersion"] = "v1.8.0"
-	specNew["imageTag"] = "1.8.0-release"
 
 	// fate version < 1.7.1
 	specOld["chartVersion"] = "v1.7.0"
-	specOld["imageTag"] = "1.7.0-release"
 	err = fum.validate(specOld, specNew)
 	assert.NotNil(t, err)
 }
@@ -79,12 +66,10 @@ func TestGetCluster(t *testing.T) {
 	specOld := modules.MapStringInterface{
 		"chartName":    "fate",
 		"chartVersion": "v1.7.2",
-		"imageTag":     "1.7.2-release",
 	}
 	specNew := modules.MapStringInterface{
 		"chartName":    "fate",
 		"chartVersion": "v1.8.0",
-		"imageTag":     "1.8.0-release",
 		"mysql": map[string]interface{}{
 			"user":     "fate",
 			"password": "fate_dev",


### PR DESCRIPTION
## Description
1. In version 1.9.0, `imageTag` is required in user configured `cluster.yaml` and it must be same with `chartVersion`. It seems like a redundant item and can be simplified by providing the info automaticly in KubeFATE. So this PR is to remove the checks between `imageTag` and `chartVersion`.
2. When installing FATE cluster with KubeFATE v1.9.0, the job will crash if `imageTag` was not specified in `cluster.yaml`.

## Tests
### Before fix
```
panic: interface conversion: interface {} is nil, not string

goroutine 129 [running]:
github.com/FederatedAI/KubeFATE/k8s-deploy/pkg/job.createCluster(0xc000140600)
	/workspace/pkg/job/cluster_install.go:224 +0x4cc
github.com/FederatedAI/KubeFATE/k8s-deploy/pkg/job.clusterInstallRun(0xc000140600)
	/workspace/pkg/job/cluster_install.go:97 +0x1b9
created by github.com/FederatedAI/KubeFATE/k8s-deploy/pkg/job.ClusterInstall
	/workspace/pkg/job/cluster_install.go:47 +0xfe
```
### After fix
No matter if user provides `imageTag` in `cluster.yaml`, KubeFATE uses the tag in `values.yaml`.
```
# kubefate cluster describe 29687885-6610-4efc-a90e-8acbe67b8676
UUID        	29687885-6610-4efc-a90e-8acbe67b8676                        
Name        	party-10000                                                 
NameSpace   	fate-10000                                                  
ChartName   	fate                                                        
ChartVersion	v1.8.0                                                      
...                                                
Spec        	backend: spark_pulsar                                       
            	chartName: fate                                             
            	chartVersion: v1.8.0                                        
            	client:                                                     
            	  accessMode: ReadWriteOnce                                 
            	  existingClaim: ""                                         
            	  size: 1Gi                                                 
            	  storageClass: null                                        
            	  subPath: client                                           
            	hdfs:                                                       
            	  datanode:                                                 
            	    accessMode: ReadWriteOnce                               
            	    existingClaim: ""                                       
            	    size: 10Gi                                              
            	    storageClass: null                                      
            	  namenode:                                                 
            	    accessMode: ReadWriteOnce                               
            	    existingClaim: ""                                       
            	    size: 3Gi                                               
            	    storageClass: null                                      
            	imageTag: 1.8.0-release 
               ...
...
```