### PR TITLE
Fix validate issue

### DIFF
--- a/k8s-deploy/examples/party-10000/cluster-spark-local-pulsar.yaml
+++ b/k8s-deploy/examples/party-10000/cluster-spark-local-pulsar.yaml
@@ -23,7 +23,7 @@ modules:
 
 computing: Spark_local
 federation: Pulsar
-storage: HDFS
+storage: LocalFS
 algorithm: Basic
 device: CPU
 

--- a/k8s-deploy/examples/party-9999/cluster-spark-local-pulsar.yaml
+++ b/k8s-deploy/examples/party-9999/cluster-spark-local-pulsar.yaml
@@ -23,7 +23,7 @@ modules:
 
 computing: Spark_local
 federation: Pulsar
-storage: HDFS
+storage: LocalFS
 algorithm: Basic
 device: CPU
 

--- a/k8s-deploy/pkg/cli/validation.go
+++ b/k8s-deploy/pkg/cli/validation.go
@@ -187,7 +187,7 @@ func compareTwoTrees(rootTemp, rootTest *TreeNode,
 	testLines, skippedKeys []string) (errs []error) {
 	valueTemp, valueTest := rootTemp.value, rootTest.value
 	typeTemp, typeTest := reflect.TypeOf(valueTemp), reflect.TypeOf(valueTest)
-	if typeTemp != typeTest {
+	if typeTemp != typeTest && typeTest != nil {
 		route := strings.Join(rootTest.route, "/")
 		errs = append(errs,
 			ConfigError(fmt.Sprintf("your yaml at '%s', line %d \n  '%s' may not match the type",

--- a/k8s-deploy/pkg/cli/validation.go
+++ b/k8s-deploy/pkg/cli/validation.go
@@ -212,7 +212,7 @@ func compareTwoTrees(rootTemp, rootTest *TreeNode,
 	case ListValue:
 		item := valueTemp.(ListValue)[0]
 		for _, v := range valueTest {
-			compareTwoTrees(item, v, testLines, skippedKeys)
+			errs = append(errs, compareTwoTrees(item, v, testLines, skippedKeys)...)
 		}
 	default:
 	}

--- a/k8s-deploy/pkg/cli/validation.go
+++ b/k8s-deploy/pkg/cli/validation.go
@@ -512,7 +512,7 @@ func checkStorage(backend map[string]string, modules []string) (errs []error) {
 				key, s, "nodemanager")))
 		}
 	case "HDFS":
-		if !Contains("hdfs", modules) && backend["computing"] != "Spark_local" {
+		if !Contains("hdfs", modules) {
 			errs = append(errs, ConfigError(fmt.Sprintf("%s %s shall work with module %s",
 				key, s, "hdfs")))
 		}

--- a/k8s-deploy/pkg/cli/validation_test.go
+++ b/k8s-deploy/pkg/cli/validation_test.go
@@ -91,6 +91,23 @@ federation: Pulsar
 storage: HDFS
 `
 
+	s9 = `
+a: 1
+b:
+- 2
+c:
+- d: 1
+- d: 2
+`
+
+	s10 = `
+a:
+b:
+c:
+- e:
+- d:
+`
+
 	sEggroll = `
 modules:
   - rollsite
@@ -149,7 +166,7 @@ modules:
 
 computing: Spark_local
 federation: Pulsar
-storage: HDFS
+storage: LocalFS
 `
 )
 
@@ -341,6 +358,7 @@ func TestValidateYaml(t *testing.T) {
 		{"validateValidYaml", args{s1, s2, nil}, []error{ConfigError("computing error, not found"), ConfigError("the modules in your yaml is not valid")}},
 		{"validateNotValidYaml", args{s1, s3, nil}, []error{ConfigError("computing error, not found"), ConfigError("the modules in your yaml is not valid"), ConfigError("your yaml at '/a/d', line 8 \n  'd: 3' may be redundant")}},
 		{"validateYamlWithskippedKeys", args{s1, s4, []string{"d"}}, []error{ConfigError("computing error, not found"), ConfigError("the modules in your yaml is not valid")}},
+		{"validateTestEmptyValue", args{s9, s10, nil}, []error{ConfigError("your yaml at '/c/@ArrayItem/e', line 5 \n  '- e:' may be redundant")}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes  ISSUE#xxx

Changes:

1. yaml storage default setting corrected
2. fix a bug which cause list obj returns no error
3. allow empty value & add test

Compare:

1. commit "yaml storage default setting corrected" correct wrong storage default setting and validate rule.

For the template and test yaml:
```yaml
// template
a: 1
b:
- 2
c:
- d: 1
- d: 2

// test
a:
b:
c:
- e:
- d:
```

2. Before  commit "fix a bug which cause list obj returns no error"
```
"your yaml at '/b', line 3 \n  'b:' may not match the type"
"your yaml at '/a', line 2 \n  'a:' may not match the type"
```

which cannot output list object validation results correctly, like  /c/@ArrayItem/e is not allowed in template /c/@ArrayItem/d.

After  commit "fix a bug which cause list obj returns no error"
```
"your yaml at '/b', line 3 \n  'b:' may not match the type"
"your yaml at '/a', line 2 \n  'a:' may not match the type"
"your yaml at '/c/@ArrayItem/e', line 5 \n  '- e:' may be redundant"
"your yaml at '/c/@ArrayItem/d', line 6 \n  '- d:' may not match the type"
```
output message correctly.

3. Before  commit "allow empty value & add test"
```
"your yaml at '/b', line 3 \n  'b:' may not match the type"
"your yaml at '/a', line 2 \n  'a:' may not match the type"
"your yaml at '/c/@ArrayItem/e', line 5 \n  '- e:' may be redundant"
"your yaml at '/c/@ArrayItem/d', line 6 \n  '- d:' may not match the type"
```
The validator doesn't allow default setting with `key: ` format if there's default value `key: value`  in template 

After  commit "allow empty value & add test"
```
"your yaml at '/c/@ArrayItem/e', line 5 \n  '- e:' may be redundant"
```
The validator will not warn the `key: ` format any more.