### PR TITLE
Fix mixed CN character in EN doc

### DIFF
--- a/docs/configurations/FATE_cluster_configuration.md
+++ b/docs/configurations/FATE_cluster_configuration.md
@@ -43,7 +43,7 @@
 | pulsar                    | mappings           | Configuration of FATE cluster `pulsar` module.                                                         |
 | skippedKeys               | sequences          | you can customize some keys which will be ignored in yaml validation                                       |
 
-***Computing federation storage algorithm device configuration introduction reference [Introduction to Engine Architecture](../Introduction_to_Engine_Architecture.md) 和 [FATE Algorithm and Computational Acceleration Selection](../FATE_Algorithm_and_Computational_Acceleration_Selection.md)***
+***Computing federation storage algorithm device configuration introduction reference [Introduction to Engine Architecture](../Introduction_to_Engine_Architecture.md) and [FATE Algorithm and Computational Acceleration Selection](../FATE_Algorithm_and_Computational_Acceleration_Selection.md)***
 
 ### list of modules
 


### PR DESCRIPTION
Signed-off-by: Chenyang Gao <gps949@outlook.com>

There's a Chinese character '和' in this English document. Just removed it.


## Description
1. We may need make the documents better for reading and learning.
2. To avoid  unnecessary Chinese in English version documents. To do better i18n.

## Tests
Just typo fix, no need testing