### PR TITLE
fix the ipcl image select bug that when driver is IPCL spark-worker is not spark-worker-ipcl

### DIFF
--- a/docker-deploy/training_template/docker-compose-spark.yml
+++ b/docker-deploy/training_template/docker-compose-spark.yml
@@ -97,7 +97,7 @@ services:
       FATE_LOG_LEVEL: "INFO"
 
   namenode:
-    image: federatedai/hadoop-namenode:2.0.0-hadoop3.2.1-java8
+    image: "federatedai/hadoop-namenode:2.0.0-hadoop3.2.1-java8"
     restart: always
     ports:
       - 9000:9000
@@ -114,7 +114,7 @@ services:
       - fate-network
 
   datanode-0:
-    image: federatedai/hadoop-datanode:2.0.0-hadoop3.2.1-java8
+    image: "federatedai/hadoop-datanode:2.0.0-hadoop3.2.1-java8"
     restart: always
     volumes:
       - ./shared_dir/data/datanode-0:/hadoop/dfs/data
@@ -126,7 +126,7 @@ services:
       - fate-network
 
   datanode-1:
-    image: federatedai/hadoop-datanode:2.0.0-hadoop3.2.1-java8
+    image: "federatedai/hadoop-datanode:2.0.0-hadoop3.2.1-java8"
     restart: always
     volumes:
       - ./shared_dir/data/datanode-1:/hadoop/dfs/data
@@ -138,7 +138,7 @@ services:
       - fate-network
 
   datanode-2:
-    image: federatedai/hadoop-datanode:2.0.0-hadoop3.2.1-java8
+    image: "federatedai/hadoop-datanode:2.0.0-hadoop3.2.1-java8"
     restart: always
     volumes:
       - ./shared_dir/data/datanode:/hadoop/dfs/data
@@ -152,7 +152,7 @@ services:
       - fate-network
 
   spark-master:
-    image: federatedai/spark-master:${TAG}
+    image: "federatedai/spark-master:${TAG}"
     restart: always
     ports:
       - "8888:8080"
@@ -165,7 +165,7 @@ services:
       - fate-network
 
   spark-worker:
-    image: federatedai/spark-worker:${TAG}
+    image: "federatedai/spark-worker:${TAG}"
     restart: always
     depends_on:
       - spark-master
@@ -180,7 +180,7 @@ services:
       - fate-network
 
   rabbitmq:
-    image: federatedai/rabbitmq:3.8.3-management
+    image: "federatedai/rabbitmq:3.8.3-management"
     ports:
       - "5672:5672"
       - "15672:15672"


### PR DESCRIPTION
Signed-off-by: Chenlong Ma <chenlongm@vmware.com>

## Description
https://github.com/FederatedAI/KubeFATE/blob/f5af31aaeab6368a65790a1d133e6726ed4c5750/docker-deploy/generate_config.sh#L253-L258
This is not expected to work when the driver is IPCL.

## Tests
```bash
# Device: IPCL, CPU
device=IPCL
```
### Before fix
```yaml
  spark-worker:
    image: federatedai/spark-worker:${TAG}
    restart: always
```
### After fix
```yaml
  spark-worker:
    image: federatedai/spark-worker-ipcl:${TAG}
    restart: always
```