### PR TITLE
Fix the bug that cannot update fate exchange

### DIFF
--- a/helm-charts/FATE-Exchange/values-template-example.yaml
+++ b/helm-charts/FATE-Exchange/values-template-example.yaml
@@ -4,6 +4,7 @@ chartName: fate-exchange
 chartVersion: v1.9.0
 partyId: 1
 registry: ""
+pullPolicy:
 imagePullSecrets: 
 - name: myregistrykey
 persistence: false

--- a/k8s-deploy/pkg/job/job.go
+++ b/k8s-deploy/pkg/job/job.go
@@ -135,6 +135,8 @@ func ClusterUpdate(clusterArgs *modules.ClusterArgs, creator string) (*modules.J
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		log.Info().Msgf("there is no upgrade manager implemented for %s", cluster.ChartName)
 	}
 
 	job := modules.NewJob(clusterArgs, "ClusterUpdate", creator, cluster.Uuid)

--- a/k8s-deploy/pkg/job/job.go
+++ b/k8s-deploy/pkg/job/job.go
@@ -129,14 +129,13 @@ func ClusterUpdate(clusterArgs *modules.ClusterArgs, creator string) (*modules.J
 		um = &FateUpgradeManager{
 			namespace: clusterArgs.Namespace,
 		}
+	default:
+		um = &FallbackUpgradeManager{}
+		log.Info().Msgf("no upgrade manager is available for %s", cluster.Name)
 	}
-	if um != nil {
-		err = um.validate(specOld, specNew)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		log.Info().Msgf("there is no upgrade manager implemented for %s", cluster.ChartName)
+	err = um.validate(specOld, specNew)
+	if err != nil {
+		return nil, err
 	}
 
 	job := modules.NewJob(clusterArgs, "ClusterUpdate", creator, cluster.Uuid)
@@ -161,9 +160,8 @@ func ClusterUpdate(clusterArgs *modules.ClusterArgs, creator string) (*modules.J
 		if dbErr != nil {
 			log.Error().Err(dbErr).Msg("Cluster.SetStatus error")
 		}
-
-		if specOld["chartVersion"].(string) != specNew["chartVersion"].(string) {
-			umCluster := um.getCluster(specOld, specNew)
+		umCluster := um.getCluster(specOld, specNew)
+		if umCluster.Name != "fallbackUM" && specOld["chartVersion"].(string) != specNew["chartVersion"].(string) {
 			// We will implicitly install a new cluster for the upgrade manager, and delete it after it finishes its job
 			err := umCluster.HelmInstall()
 			if err != nil {

--- a/k8s-deploy/pkg/job/job.go
+++ b/k8s-deploy/pkg/job/job.go
@@ -130,9 +130,11 @@ func ClusterUpdate(clusterArgs *modules.ClusterArgs, creator string) (*modules.J
 			namespace: clusterArgs.Namespace,
 		}
 	}
-	err = um.validate(specOld, specNew)
-	if err != nil {
-		return nil, err
+	if um != nil {
+		err = um.validate(specOld, specNew)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	job := modules.NewJob(clusterArgs, "ClusterUpdate", creator, cluster.Uuid)

--- a/k8s-deploy/pkg/job/upgrade_manager.go
+++ b/k8s-deploy/pkg/job/upgrade_manager.go
@@ -22,3 +22,21 @@ type UpgradeManager interface {
 	getCluster(specOld, specNew modules.MapStringInterface) modules.Cluster
 	waitFinish(interval, round int) bool
 }
+
+type FallbackUpgradeManager struct {
+	UpgradeManager
+}
+
+func (um *FallbackUpgradeManager) validate(specold, specNew modules.MapStringInterface) error {
+	return nil
+}
+
+func (um *FallbackUpgradeManager) getCluster(specold, specNew modules.MapStringInterface) modules.Cluster {
+	return modules.Cluster{
+		Name: "fallbackUM",
+	}
+}
+
+func (um *FallbackUpgradeManager) waitFinish(interval, round int) bool {
+	return true
+}


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

Fixes ISSUE #763 

## Description
1. Tell the story why you need to make this change from the user's perspective.

The user is facing a regression when use kubefate to update fate-serving and fate-exchange.
Also, find that the yaml validate reported a false alarm, so we need to add the "pullPolicy" in to the example file, to make the validator find this item in the dictionary.

3. What will be the pain point if you don't make this change?

Regression.

## Tests
### Before fix

We have been reported that kubefate will crash when update fate-exchange.

### After fix
Can update fate-exchange sucessfully by "kubefate cluster update"