### PR TITLE
[issue-747] Support fate flow ha

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,7 @@ Fixes ISSUE #xxx
 ## Description
 1. Tell the story why you need to make this change from the user's perspective.
 2. What will be the pain point if you don't make this change?
+3. In summary, what did you change reach your goal?
 
 ## Tests
 ### Before fix

--- a/helm-charts/FATE/templates/core/fateboard.yaml
+++ b/helm-charts/FATE/templates/core/fateboard.yaml
@@ -1,0 +1,106 @@
+# Copyright 2019-2022 VMware, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.modules.fateboard.include }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fateboard
+  labels:
+    fateMoudle: fateboard
+{{ include "fate.labels" . | indent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      fateMoudle: fateboard
+{{ include "fate.matchLabels" . | indent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.istio.enabled }}
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
+        {{- end }}
+      labels:
+        fateMoudle: fateboard
+{{ include "fate.labels" . | indent 8 }}
+    spec:
+      containers:
+        {{- if .Values.modules.fateboard.include }}
+        - image: {{ .Values.image.registry }}/fateboard:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: fateboard
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: livenessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: readinessProbe
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 8080
+              httpHeaders:
+                - name: X-Custom-Header
+                  value: startupProbe
+            failureThreshold: 12
+            periodSeconds: 10
+          volumeMounts:
+            - mountPath: /data/projects/fate/fateboard/conf/application.properties
+              name: fateboard-confs
+              subPath: application.properties
+        {{- end }}
+      {{- with .Values.modules.fateboard.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.modules.fateboard.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.modules.fateboard.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 6 }}
+      {{- end }}
+      restartPolicy: Always
+      volumes:
+        {{- if .Values.modules.fateboard.include }}
+        - name: fateboard-confs
+          configMap:
+            name: fateboard-config
+        {{- end }}
+{{- end }}

--- a/helm-charts/FATE/templates/core/fateboard/configmap.yaml
+++ b/helm-charts/FATE/templates/core/fateboard/configmap.yaml
@@ -24,6 +24,11 @@ data:
     #priority is higher than {fateflow.url}, split by ;
     #below config can support configuring more than one fate flow for this fate board
     fateflow.url-list=
+    {{- $replicaCount := .Values.modules.python.replicas | int -}}
+    {{- range $index0 := until $replicaCount }}
+      {{- $index1 := $index0 | add1 -}}
+      http://python-{{ $index0 }}.fateflow:9380{{ if ne $index1 $replicaCount }};{{ end }}
+    {{- end }}
     fateflow.http_app_key=
     fateflow.http_secret_key=
     spring.http.encoding.charset=UTF-8

--- a/helm-charts/FATE/templates/core/fateboard/service.yaml
+++ b/helm-charts/FATE/templates/core/fateboard/service.yaml
@@ -15,7 +15,7 @@ kind: Service
 metadata:
   name: fateboard
   labels:
-    fateMoudle: python
+    fateMoudle: fateboard
 {{ include "fate.labels" . | indent 4 }}
 spec:
   ports:
@@ -25,6 +25,6 @@ spec:
       protocol: TCP
   type: {{ .Values.modules.fateboard.type }}
   selector:
-    fateMoudle: python
+    fateMoudle: fateboard
 {{ include "fate.matchLabels" . | indent 4 }}
 {{- end }}

--- a/helm-charts/FATE/templates/core/fateflow/configmap.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/configmap.yaml
@@ -67,9 +67,19 @@ data:
       dataset: false
     fateflow:
       # you must set real ip address, 127.0.0.1 and 0.0.0.0 is not supported
-      host: fateflow
+      host: fateflow_ip
       http_port: 9380
       grpc_port: 9360
+      # when you have multiple fateflow server on one party,
+      # we suggest using nginx for load balancing.
+      nginx:
+        # under K8s mode, 'fateflow' is the service name, which will be a L4 load balancer.
+        host: fateflow
+        http_port: 9380
+        grpc_port: 9360
+      # use random instance_id instead of {host}:{http_port}
+      random_instance_id: false
+
       # support rollsite/nginx/fateflow as a coordination proxy
       # rollsite support fate on eggroll, use grpc protocol
       # nginx support fate on eggroll and fate on spark, use http or grpc protocol, default is http
@@ -247,8 +257,8 @@ data:
     federated_command_trys: 3
     end_status_job_scheduling_time_limit: 300000 # ms
     end_status_job_scheduling_updates: 1
-    auto_retries: 0
-    auto_retry_delay: 1  #seconds
+    auto_retries: {{ .Values.modules.python.failedTaskAutoRetryTimes }}
+    auto_retry_delay: {{ .Values.modules.python.failedTaskAutoRetryDelay }}  #seconds
     # It can also be specified in the job configuration using the federated_status_collect_type parameter
     federated_status_collect_type: PUSH
     detect_connect_max_retry_count: 3

--- a/helm-charts/FATE/templates/core/fateflow/service.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/service.yaml
@@ -22,29 +22,6 @@ spec:
     - name: "tcp-grpc"
       port: 9360
       targetPort: 9360
-      protocol: TCP
-    - name: "tcp-http"
-      port: 9380
-      targetPort: 9380
-      protocol: TCP
-  type: ClusterIP
-  clusterIP: None
-  selector:
-    fateMoudle: python
-{{ include "fate.matchLabels" . | indent 4 }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: fateflow-client
-  labels:
-    fateMoudle: fateflow
-{{ include "fate.labels" . | indent 4 }}
-spec:
-  ports:
-    - name: "tcp-grpc"
-      port: 9360
-      targetPort: 9360
       {{- if eq .Values.modules.python.type "NodePort" "LoadBalancer" }}
       nodePort: {{ .Values.modules.python.grpcNodePort }}
       {{- end }}
@@ -57,11 +34,9 @@ spec:
       {{- end }}
       protocol: TCP
   type: {{ .Values.modules.python.type }}
-  
   {{- if .Values.modules.python.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.modules.python.loadBalancerIP }}"
   {{- end }}
-  
   selector:
     fateMoudle: python
 {{ include "fate.matchLabels" . | indent 4 }}

--- a/helm-charts/FATE/templates/core/python-spark.yaml
+++ b/helm-charts/FATE/templates/core/python-spark.yaml
@@ -19,7 +19,7 @@ metadata:
 {{ include "fate.labels" . | indent 4 }}
 spec:
   serviceName: fateflow
-  replicas: 1
+  replicas: {{ .Values.modules.python.replicas }}
   selector:
     matchLabels:
       fateMoudle: python
@@ -123,7 +123,7 @@ spec:
                 cp /data/projects/fate/conf-tmp/component_registry.json /data/projects/fate/fateflow/conf/component_registry.json
                 cp /data/projects/fate/conf-tmp/job_default_config.yaml /data/projects/fate/fateflow/conf/job_default_config.yaml
                 # fix fateflow conf must use IP
-                sed -i "s/host: fateflow/host: ${POD_IP}/g" /data/projects/fate/conf/service_conf.yaml
+                sed -i "s/host: fateflow_ip/host: ${POD_IP}/g" /data/projects/fate/conf/service_conf.yaml
                 
                 cp /data/projects/spark-3.1.3-bin-hadoop3.2/conf/spark-defaults-template.conf /data/projects/spark-3.1.3-bin-hadoop3.2/conf/spark-defaults.conf
                 sed -i "s/fateflow/${POD_IP}/g" /data/projects/spark-3.1.3-bin-hadoop3.2/conf/spark-defaults.conf
@@ -178,53 +178,6 @@ spec:
             - mountPath: /data/projects/fate/fateflow/model_local_cache
               name: python-data
               subPath: model-local-cache
-        {{- if .Values.modules.fateboard.include }}
-        - image: {{ .Values.image.registry }}/fateboard:{{ .Values.image.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          name: fateboard
-          ports:
-            - containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 8080
-              httpHeaders:
-                - name: X-Custom-Header
-                  value: livenessProbe
-            initialDelaySeconds: 1
-            periodSeconds: 10
-            timeoutSeconds: 3
-            successThreshold: 1
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 8080
-              httpHeaders:
-                - name: X-Custom-Header
-                  value: readinessProbe
-            initialDelaySeconds: 1
-            periodSeconds: 10
-            timeoutSeconds: 3
-            successThreshold: 1
-            failureThreshold: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 8080
-              httpHeaders:
-                - name: X-Custom-Header
-                  value: startupProbe
-            failureThreshold: 12
-            periodSeconds: 10
-          volumeMounts:
-            - mountPath: /data/projects/fate/fateboard/conf/application.properties
-              name: fateboard-confs
-              subPath: application.properties
-            - name: python-data
-              mountPath: /data/projects/fate/fateflow/logs
-              subPath: logs
-        {{- end }}
       {{- with .Values.modules.python.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -265,11 +218,6 @@ spec:
         - name: pulsar-route-table
           configMap:
             name: pulsar-route-table
-        {{- end }}
-        {{- if .Values.modules.fateboard.include }}
-        - name: fateboard-confs
-          configMap:
-            name: fateboard-config
         {{- end }}
         {{- if not .Values.persistence.enabled }}
         - name: python-data

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -155,65 +155,70 @@ skippedKeys:
 
 
 # python:
-  # type: NodePort
-  # httpNodePort: 30097
-  # grpcNodePort: 30092
-  # loadBalancerIP:
-  # serviceAccountName: ""
-  # nodeSelector:
-  # tolerations:
-  # affinity:
-  # enabledNN: false
-  # logLevel: INFO
-  # existingClaim: ""
-  # storageClass: "python"
-  # accessMode: ReadWriteMany
-  # size: 1Gi
-  # resources:
-    # requests:
-      # cpu: "2"
-      # memory: "4Gi"
-    # limits:
-      # cpu: "4"
-      # memory: "8Gi"
-  # clustermanager:
-    # cores_per_node: 16
-    # nodes: 2
-  # spark:
-    # cores_per_node: 20
-    # nodes: 2
-    # master: spark://spark-master:7077
-    # driverHost:
-    # driverHostType:
-    # portMaxRetries:
-    # driverStartPort:
-    # blockManagerStartPort:
-    # pysparkPython:
-  # hdfs:
-    # name_node: hdfs://namenode:9000
-    # path_prefix:
-  # rabbitmq:
-    # host: rabbitmq
-    # mng_port: 15672
-    # port: 5672
-    # user: fate
-    # password: fate
-  # pulsar:
-    # host: pulsar
-    # mng_port: 8080
-    # port: 6650
-    # topic_ttl: 3
-    # cluster: standalone
-    # tenant: fl-tenant     
-  # nginx:
-    # host: nginx
-    # http_port: 9300
-    # grpc_port: 9310
+#   type: NodePort
+#   replicas: 1
+#   httpNodePort: 30097
+#   grpcNodePort: 30092
+#   loadBalancerIP:
+#   serviceAccountName: ""
+#   nodeSelector:
+#   tolerations:
+#   affinity:
+#   failedTaskAutoRetryTimes:
+#   failedTaskAutoRetryDelay:
+#   logLevel: INFO
+#   existingClaim: ""
+#   storageClass: "python"
+#   accessMode: ReadWriteMany
+#   size: 1Gi
+#   resources:
+#     requests:
+#       cpu: "2"
+#       memory: "4Gi"
+#     limits:
+#       cpu: "4"
+#       memory: "8Gi"
+#   clustermanager:
+#     cores_per_node: 16
+#     nodes: 2
+#   spark:
+#     cores_per_node: 20
+#     nodes: 2
+#     master: spark://spark-master:7077
+#     driverHost:
+#     driverHostType:
+#     portMaxRetries:
+#     driverStartPort:
+#     blockManagerStartPort:
+#     pysparkPython:
+#   hdfs:
+#     name_node: hdfs://namenode:9000
+#     path_prefix:
+#   rabbitmq:
+#     host: rabbitmq
+#     mng_port: 15672
+#     port: 5672
+#     user: fate
+#     password: fate
+#   pulsar:
+#     host: pulsar
+#     mng_port: 8080
+#     port: 6650
+#     topic_ttl: 3
+#     cluster: standalone
+#     tenant: fl-tenant
+#   nginx:
+#     host: nginx
+#     http_port: 9300
+#     grpc_port: 9310
 
 # fateboard:
-  # type: ClusterIP
-  # username: admin
-  # password: admin
+#   type: ClusterIP
+#   username: admin
+#   password: admin
+#   nodeSelector:
+#   tolerations:
+#   affinity:
 
 # client:
   # nodeSelector:

--- a/helm-charts/FATE/values-template.yaml
+++ b/helm-charts/FATE/values-template.yaml
@@ -217,6 +217,7 @@ modules:
   python: 
     include: {{ has "python" .modules }}
     {{- with .python }}
+    replicas: {{ .replicas }}
     {{- with .resources }}
     resources:
 {{ toYaml . | indent 6 }}
@@ -239,6 +240,8 @@ modules:
     affinity:
 {{ toYaml . | indent 6 }}
     {{- end }}
+    failedTaskAutoRetryTimes: {{ .failedTaskAutoRetryTimes | default 5 }}
+    failedTaskAutoRetryDelay: {{ .failedTaskAutoRetryDelay | default 60 }}
     existingClaim: {{ .existingClaim  }}
     claimName: {{ .claimName | default "python-data" }}
     storageClass: {{ .storageClass | default "python" }}
@@ -405,6 +408,18 @@ modules:
     type: {{ .type }}
     username: {{ .username }}
     password: {{ .password }}
+    {{- with .nodeSelector }}
+    nodeSelector:
+{{ toYaml . | indent 6 }}
+    {{- end }}
+    {{- with .tolerations }}
+    tolerations:
+{{ toYaml . | indent 6 }}
+    {{- end }}
+    {{- with .affinity }}
+    affinity:
+{{ toYaml . | indent 6 }}
+    {{- end }}
     {{- end}}
 
   spark:

--- a/helm-charts/FATE/values.yaml
+++ b/helm-charts/FATE/values.yaml
@@ -120,6 +120,7 @@ modules:
     affinity:
   python: 
     include: true
+    replicas: 1
     type: ClusterIP
     httpNodePort: 30097
     grpcNodePort: 30092
@@ -128,6 +129,8 @@ modules:
     nodeSelector:
     tolerations:
     affinity:
+    failedTaskAutoRetryTimes:
+    failedTaskAutoRetryDelay:
     logLevel: INFO
     # subPath: ""
     existingClaim:
@@ -204,19 +207,6 @@ modules:
         cpu: "2"
         memory: "4Gi"
 
-  client: 
-    include: true
-    ip: client
-    type: ClusterIP
-    nodeSelector:
-    tolerations:
-    affinity:
-    subPath: "client"
-    existingClaim:
-    storageClass:
-    accessMode: ReadWriteOnce
-    size: 1Gi
-
   mysql: 
     include: true
     type: ClusterIP
@@ -251,6 +241,9 @@ modules:
     type: ClusterIP
     username: admin
     password: admin
+    nodeSelector:
+    tolerations:
+    affinity:
 
   spark:
     include: true

--- a/k8s-deploy/cluster-spark-pulsar.yaml
+++ b/k8s-deploy/cluster-spark-pulsar.yaml
@@ -63,7 +63,6 @@ skippedKeys:
   # nodeSelector:
   # tolerations:
   # affinity:
-  # enabledNN: false
   # logLevel: INFO
   # existingClaim: ""
   # storageClass: "python"

--- a/k8s-deploy/cluster.yaml
+++ b/k8s-deploy/cluster.yaml
@@ -129,7 +129,6 @@ skippedKeys:
   # nodeSelector:
   # tolerations:
   # affinity:
-  # enabledNN: false
   # logLevel: INFO
   # existingClaim: ""
   # storageClass: "python"


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

Fixes ISSUE #747 

## Description
1. Tell the story why you need to make this change from the user's perspective.
Feature request.
2. What will be the pain point if you don't make this change?
Cannot enjoy flow ha feature.
3. In summary, what did you change reach your goal?

- Seperate the fateboard container and the fateflow container.
- In fateboard's configmap, set the fateflow.url-list based on the replica number of fateflow.
- In fateflow's configmap, set the fateflow service name as the entry point of the requests, this is L4 load balancing.
- Remove fateflow-client service. We need this svc because we used to need fateflow service to be a headless service, and at the same time we need the fateflow service to be an external service. This conflict makes we have to set 2 services for the flow pods. This is not necessary now.
- Expose the retry times and delay configurations of fateflow.
- Remove some unnecessary configurations.

## Tests
### Before fix
Cannot have the HA feature
### After fix

- Verified that fateboard and flow work fine, including training, predicting, and the fateboard functionalities.
- Verified that we can set the replicas of flow to 2, then, 2 flows can run tasks in parellel when in spark mode.
- In eggroll mode, because eggroll holds a long connection with fateflow, thus it cannot enjoy the L4 load balancer. But, when I shut down one flow in the half way of a training job. The other flow will take over the unfinished job and make it done.
- Verified that fate-serving can work properly.

The config.yaml I used for fate-9999:
```
name: fate-9999
namespace: fate-9999
chartName: fate
chartVersion: v1.9.0
partyId: 9999
registry: ""
pullPolicy:
imagePullSecrets:
  - name: myregistrykey
persistence: true
istio:
  enabled: false
podSecurityPolicy:
  enabled: false
ingressClassName: nginx
modules:
  - mysql
  - python
  - fateboard
  - client
  - spark
  - hdfs
  - nginx
  - pulsar

computing: Spark
federation: Pulsar
storage: HDFS
algorithm: Basic
device: CPU

ingress:
  fateboard:
    hosts:
      - name: party9999.fateboard.example.com
  client:
    hosts:
      - name: party9999.notebook.example.com
  spark:
    hosts:
      - name: party9999.spark.example.com
  pulsar:
    hosts:
      - name: party9999.pulsar.example.com

python:
  replicas: 2
  type: NodePort
  httpNodePort: 30097
  grpcNodePort: 30092
  logLevel: INFO
  storageClass: standard

client:
  storageClass: standard

servingIp: 10.182.130.97
servingPort: 30095

mysql:
  storageClass: standard

nginx:
  type: NodePort
  httpNodePort: 30093
  grpcNodePort: 30098
  route_table:
    10000:
      fateflow:
        - host: 10.182.130.97
          http_port: 30103
          grpc_port: 30108

pulsar:
  type: NodePort
  httpNodePort: 30094
  httpsNodePort: 30099
  publicLB:
    enabled: false
  route_table:
    9999:
      host: pulsar
      port: 6650
      sslPort: 6651
    10000:
      host: 10.182.130.97
      port: 30104
      sslPort: 30109
      proxy: ""

serving:
  useRegistry: true
  zookeeper:
    hosts:
      - serving-zookeeper.fate-serving-9999:2181
    use_acl: false
    user: fate
    password: fate
```

And fate serving-9999:
```
name: fate-serving-9999
namespace: fate-serving-9999
chartName: fate-serving
chartVersion: v2.1.6
partyId: 9999
registry: ""
pullPolicy:
imagePullSecrets: 
- name: myregistrykey
persistence: false
istio:
  enabled: false
podSecurityPolicy:
  enabled: false
ingressClassName: nginx
modules:
  - servingProxy
  - servingRedis
  - servingServer
  - servingZookeeper
  - servingAdmin
  
ingress:
  servingProxy: 
    hosts:
    - name: party9999.serving-proxy.example.com
      path: /
  servingAdmin: 
    hosts:
    - name: party9999.serving-admin.example.com
      path: /
      
servingAdmin:
  username: admin
  password: admin

servingProxy: 
  nodePort: 30096
  type: NodePort
  partyList:
  - partyId: 10000
    partyIp: 10.182.130.97
    partyPort: 30106

servingServer:
  type: NodePort
  nodePort: 30095
  fateflow:
    ip: 10.182.130.97
    port: 30097
  cacheSwitch: true
  cacheType: "redis"
  singleAdaptor: com.webank.ai.fate.serving.adaptor.dataaccess.MockAdapter
  batchAdaptor: com.webank.ai.fate.serving.adaptor.dataaccess.MockBatchAdapter
  AdapterURL: http://127.0.0.1:9380/v1/http/adapter/getFeature
```