### PR TITLE
trying to build arm64 version kubefate

### DIFF
--- a/k8s-deploy/Dockerfile
+++ b/k8s-deploy/Dockerfile
@@ -1,3 +1,5 @@
+ARG ARCH=amd64
+
 FROM golang:1.17 as builder
 
 WORKDIR /workspace
@@ -13,9 +15,9 @@ COPY docs/docs.go docs/docs.go
 COPY config.yaml config.yaml
 
 ARG LDFLAGS
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags '-s' -installsuffix cgo -o kubefate kubefate.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on go build -a -ldflags '-s' -installsuffix cgo -o kubefate kubefate.go
 
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot-${ARCH}
 WORKDIR /
 COPY --from=builder /workspace/kubefate .
 COPY --from=builder /workspace/config.yaml  .

--- a/k8s-deploy/Dockerfile
+++ b/k8s-deploy/Dockerfile
@@ -15,6 +15,7 @@ COPY docs/docs.go docs/docs.go
 COPY config.yaml config.yaml
 
 ARG LDFLAGS
+ARG ARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on go build -a -ldflags '-s' -installsuffix cgo -o kubefate kubefate.go
 
 FROM gcr.io/distroless/static:nonroot-${ARCH}

--- a/k8s-deploy/Makefile
+++ b/k8s-deploy/Makefile
@@ -70,12 +70,12 @@ swag: swag-bin
 package: kubefate-without-swag
 	mkdir -p tmp/kubefate;
 	cp -r bin/kubefate *.yaml examples tmp/kubefate;
-	tar -czvf kubefate-k8s-${VERSION}-${ARCH}.tar.gz -C tmp/ kubefate;
+	tar -czvf kubefate-k8s-${RELEASE_VERSION}-${ARCH}.tar.gz -C tmp/ kubefate;
 	rm -r tmp;
 
 release: package docker-save
-	mkdir -p release/${ARCH};
-	mv kubefate-k8s-${VERSION}-${ARCH}.tar.gz kubefate-${VERSION}-${ARCH}.docker release/${ARCH};
+	mkdir -p release;
+	mv kubefate-k8s-${RELEASE_VERSION}-${ARCH}.tar.gz kubefate-${VERSION}-${ARCH}.docker release/;
 
 clean:
 	rm -r release

--- a/k8s-deploy/Makefile
+++ b/k8s-deploy/Makefile
@@ -2,6 +2,7 @@ NAME ?= federatedai/kubefate
 VERSION ?= v1.4.5
 IMG ?= ${NAME}:${VERSION}
 ARCH ?= amd64
+GOOS ?= linux
 
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -27,10 +28,10 @@ test: fmt vet
 
 # Build manager binary
 kubefate: fmt vet swag
-	GOARCH=${ARCH} CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
+	GOOS=${GOOS} GOARCH=${ARCH} CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
 
 kubefate-without-swag: fmt vet
-	GOARCH=${ARCH} CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
+	GOOS=${GOOS} GOARCH=${ARCH} CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
 
 run: fmt vet 
 	go run ./kubefate.go service
@@ -44,10 +45,10 @@ uninstall:
 	kubectl delete -f rbac-config.yaml
 
 docker-build: test
-	docker build . -t ${IMG}
+	docker build --build-arg ARCH=${ARCH} . -t ${IMG}
 
 docker-build-without-test:
-	docker build . -t ${IMG}
+	docker build --build-arg ARCH=${ARCH} . -t ${IMG}
 
 docker-push:
 	docker push ${IMG}

--- a/k8s-deploy/Makefile
+++ b/k8s-deploy/Makefile
@@ -1,6 +1,7 @@
 NAME ?= federatedai/kubefate
 VERSION ?= v1.4.5
 IMG ?= ${NAME}:${VERSION}
+ARCH ?= amd64
 
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -26,10 +27,10 @@ test: fmt vet
 
 # Build manager binary
 kubefate: fmt vet swag
-	CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
+	GOARCH=${ARCH} CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
 
 kubefate-without-swag: fmt vet
-	CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
+	GOARCH=${ARCH} CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -o ${OUTPUT_FILE} ${BUILD_MODE} kubefate.go
 
 run: fmt vet 
 	go run ./kubefate.go service
@@ -52,7 +53,7 @@ docker-push:
 	docker push ${IMG}
 
 docker-save: docker-build-without-test
-	docker save -o kubefate-${VERSION}.docker ${IMG} 
+	docker save -o kubefate-${VERSION}-${ARCH}.docker ${IMG}
 
 # Run go fmt against code
 fmt:
@@ -68,12 +69,12 @@ swag: swag-bin
 package: kubefate-without-swag
 	mkdir -p tmp/kubefate;
 	cp -r bin/kubefate *.yaml examples tmp/kubefate;
-	tar -czvf kubefate-k8s-${RELEASE_VERSION}.tar.gz -C tmp/ kubefate;
+	tar -czvf kubefate-k8s-${VERSION}-${ARCH}.tar.gz -C tmp/ kubefate;
 	rm -r tmp;
 
 release: package docker-save
-	mkdir -p release;
-	mv kubefate-k8s-${RELEASE_VERSION}.tar.gz kubefate-${VERSION}.docker release/;
+	mkdir -p release/${ARCH};
+	mv kubefate-k8s-${VERSION}-${ARCH}.tar.gz kubefate-${VERSION}-${ARCH}.docker release/${ARCH};
 
 clean:
 	rm -r release


### PR DESCRIPTION
## Description
构建一个可以运行在 arm 服务器上的kubefate 可执行文件，以及 kubefate 镜像

可以通过在执行makefile的时候添加arch 参数来指定目标架构

```
ARCH=arm64 make release
ARCH=amd64 make release
```

生成的镜像以及可执行文件，会存放在 `release`目录里

```
release
├── amd64
│   ├── kubefate-k8s-v1.4.5-amd64.tar.gz
│   └── kubefate-v1.4.5-amd64.docker
└── arm64
    ├── kubefate-k8s-v1.4.5-arm64.tar.gz
    └── kubefate-v1.4.5-arm64.docker
```

另外`docker save` 的镜像最好可以改成压缩格式的，可以进一步缩小体积
@jat001 @LaynePeng 