### PR TITLE
fix the issue exsiting claim doesn't work for nodemanger

### DIFF
--- a/helm-charts/FATE/values-template.yaml
+++ b/helm-charts/FATE/values-template.yaml
@@ -319,7 +319,8 @@ modules:
     sessionProcessorsPerNode: {{ .sessionProcessorsPerNode }}
     replicas: {{ .replicas | default 2 }}
     subPath: {{ .subPath }}
-    storageClass: {{ .storageClass  | default "client" }}
+    storageClass: {{ .storageClass  | default "nodemanager" }}
+    existingClaim: {{ .existingClaim }}
     accessMode: {{ .accessMode  | default "ReadWriteOnce" }}
     size: {{ .size  | default "1Gi" }}
     {{- with .nodeSelector }}

--- a/helm-charts/Makefile
+++ b/helm-charts/Makefile
@@ -2,7 +2,9 @@ release:
 	helm package ./FATE
 	helm package ./FATE-Serving
 	helm package ./FATE-Exchange
+	helm package ./UpgradeManager
 lint:
 	helm lint ./FATE
 	helm lint ./FATE-Serving
 	helm lint ./FATE-Exchange
+	helm lint ./UpgradeManager


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

## Description
1. Tell the story why you need to make this change from the user's perspective.
Cannot set existing claim for nodemanager.
Although there is a problem for 2 replicas sharing one pv for a statefulsets, e.g., the 2 pods must be scheduled to one node, the existingClaim still should be a valid configuration when we set only one replica for node manager.
2. What will be the pain point if you don't make this change?
I will forget to package the helm chart of FUM