### PR TITLE
fix bug: some parameter name in model_store_address not correct

### DIFF
--- a/helm-charts/FATE/templates/core/fateflow/configmap.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/configmap.yaml
@@ -187,11 +187,11 @@ data:
     enable_model_store: true
     model_store_address:
       storage: mysql
-      name: {{ .Values.externalMysqlDatabase | default .Values.modules.mysql.database | default "eggroll_meta" }}
+      database: {{ .Values.externalMysqlDatabase | default .Values.modules.mysql.database | default "eggroll_meta" }}
       host: '{{ .Values.externalMysqlIp | default .Values.modules.mysql.ip | default "mysql" }}'
       port: {{ .Values.externalMysqlPort | default .Values.modules.mysql.port | default "3306" }}
       user: '{{ .Values.externalMysqlUser | default .Values.modules.mysql.user | default "fate" }}'
-      passwd: '{{ .Values.externalMysqlPassword | default .Values.modules.mysql.password | default "fate_dev" }}'
+      password: '{{ .Values.externalMysqlPassword | default .Values.modules.mysql.password | default "fate_dev" }}'
       max_connections: 10
       stale_timeout: 10
     {{- with .Values.modules.serving }}


### PR DESCRIPTION
update parameter name in model_store_address. according to [service_conf.yaml](https://github.com/FederatedAI/FATE/blob/91d247d3a810144130feb672c52c311f29fd772a/conf/service_conf.yaml#L144-L151)

```
model_store_address:
# use mysql as the model store engine
#  storage: mysql
#  database: fate_model
#  user: fate
#  password: fate
#  host: 127.0.0.1
#  port: 3306
```

@LaynePeng 