### PR TITLE
support jupyter notebook password setting

### DIFF
--- a/docker-deploy/generate_config.sh
+++ b/docker-deploy/generate_config.sh
@@ -229,6 +229,7 @@ GenerateConfig() {
 		fi
 
 		cp ${WORKINGDIR}/.env ./confs-$party_id
+		echo "NOTEBOOK_HASHED_PASSWORD=${notebook_hashed_password}" >> ./confs-$party_id/.env
 
 		# Modify the configuration file
 
@@ -494,6 +495,7 @@ EOF
 			rm -rf confs-exchange/
 			mkdir -p confs-exchange/conf/
 			cp ${WORKINGDIR}/.env confs-exchange/
+			echo "NOTEBOOK_HASHED_PASSWORD=${notebook_hashed_password}" >> confs-exchange/.env
 			cp training_template/docker-compose-exchange.yml confs-exchange/docker-compose.yml
 			cp -r training_template/backends/eggroll/conf/* confs-exchange/conf/
 
@@ -565,6 +567,7 @@ EOF
 		fi
 		# generate conf dir
 		cp ${WORKINGDIR}/.env ./serving-$party_id
+		echo "NOTEBOOK_HASHED_PASSWORD=${notebook_hashed_password}" >> ./serving-$party_id/.env
 
 		# serving admin
 		sed -i "s/admin.username=<serving_admin.username>/admin.username=${serving_admin_username}/g" ./serving-$party_id/confs/serving-admin/conf/application.properties

--- a/docker-deploy/generate_config.sh
+++ b/docker-deploy/generate_config.sh
@@ -495,7 +495,7 @@ EOF
 			rm -rf confs-exchange/
 			mkdir -p confs-exchange/conf/
 			cp ${WORKINGDIR}/.env confs-exchange/
-			echo "NOTEBOOK_HASHED_PASSWORD=${notebook_hashed_password}" >> confs-exchange/.env
+
 			cp training_template/docker-compose-exchange.yml confs-exchange/docker-compose.yml
 			cp -r training_template/backends/eggroll/conf/* confs-exchange/conf/
 
@@ -567,7 +567,6 @@ EOF
 		fi
 		# generate conf dir
 		cp ${WORKINGDIR}/.env ./serving-$party_id
-		echo "NOTEBOOK_HASHED_PASSWORD=${notebook_hashed_password}" >> ./serving-$party_id/.env
 
 		# serving admin
 		sed -i "s/admin.username=<serving_admin.username>/admin.username=${serving_admin_username}/g" ./serving-$party_id/confs/serving-admin/conf/application.properties

--- a/docker-deploy/parties.conf
+++ b/docker-deploy/parties.conf
@@ -39,3 +39,6 @@ fateboard_password=admin
 # Define serving admin login information
 serving_admin_username=admin
 serving_admin_password=admin
+
+# Define notebook login information
+notebook_hashed_password=

--- a/docker-deploy/training_template/docker-compose-eggroll.yml
+++ b/docker-deploy/training_template/docker-compose-eggroll.yml
@@ -153,6 +153,7 @@ services:
       FATE_FLOW_IP: "fateflow"
       FATE_FLOW_PORT: "9380"
       FATE_SERVING_HOST: "fate-serving:8059"
+      NOTEBOOK_HASHED_PASSWORD: "${NOTEBOOK_HASHED_PASSWORD}"
     volumes:
       - download_dir:/data/projects/fate/download_dir
       - shared_dir_examples:/data/projects/fate/examples
@@ -161,6 +162,7 @@ services:
       - fateflow
     networks:
       - fate-network
+    command: ["bash", "-c", "flow init --ip ${FATE_FLOW_IP} --port ${FATE_FLOW_PORT} && pipeline init --ip ${FATE_FLOW_IP} --port ${FATE_FLOW_PORT} && jupyter notebook --ip=0.0.0.0 --port=20000 --allow-root --debug --NotebookApp.notebook_dir='/data/projects/fate/' --no-browser --NotebookApp.token='' --NotebookApp.password='${NOTEBOOK_HASHED_PASSWORD}'"]
 
   mysql:
     image: "mysql:8.0.28"

--- a/docker-deploy/training_template/docker-compose-spark-slim.yml
+++ b/docker-deploy/training_template/docker-compose-spark-slim.yml
@@ -169,6 +169,7 @@ services:
       FATE_FLOW_IP: "fateflow"
       FATE_FLOW_PORT: "9380"
       FATE_SERVING_HOST: "fate-serving:8059"
+      NOTEBOOK_HASHED_PASSWORD: "${NOTEBOOK_HASHED_PASSWORD}"
     volumes:
       - download_dir:/data/projects/fate/download_dir
       - shared_dir_examples:/data/projects/fate/examples
@@ -177,3 +178,4 @@ services:
       - fateflow
     networks:
       - fate-network
+    command: ["bash", "-c", "flow init --ip ${FATE_FLOW_IP} --port ${FATE_FLOW_PORT} && pipeline init --ip ${FATE_FLOW_IP} --port ${FATE_FLOW_PORT} && jupyter notebook --ip=0.0.0.0 --port=20000 --allow-root --debug --NotebookApp.notebook_dir='/data/projects/fate/' --no-browser --NotebookApp.token='' --NotebookApp.password='${NOTEBOOK_HASHED_PASSWORD}'"]

--- a/docker-deploy/training_template/docker-compose-spark.yml
+++ b/docker-deploy/training_template/docker-compose-spark.yml
@@ -254,6 +254,7 @@ services:
       FATE_FLOW_IP: "fateflow"
       FATE_FLOW_PORT: "9380"
       FATE_SERVING_HOST: "fate-serving:8059"
+      NOTEBOOK_HASHED_PASSWORD: "${NOTEBOOK_HASHED_PASSWORD}"
     volumes:
       - download_dir:/data/projects/fate/download_dir
       - shared_dir_examples:/data/projects/fate/examples
@@ -262,3 +263,4 @@ services:
       - fateflow
     networks:
       - fate-network
+    command: ["bash", "-c", "flow init --ip ${FATE_FLOW_IP} --port ${FATE_FLOW_PORT} && pipeline init --ip ${FATE_FLOW_IP} --port ${FATE_FLOW_PORT} && jupyter notebook --ip=0.0.0.0 --port=20000 --allow-root --debug --NotebookApp.notebook_dir='/data/projects/fate/' --no-browser --NotebookApp.token='' --NotebookApp.password='${NOTEBOOK_HASHED_PASSWORD}'"]

--- a/docs/configurations/FATE_cluster_configuration.md
+++ b/docs/configurations/FATE_cluster_configuration.md
@@ -168,14 +168,15 @@ Configuration of kubernetes deployment fateboard.
 
 Configuration of kubernetes deployment client.
 
-| Name          | Type     | Description                                                                                                                                                     |
-| ------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| nodeSelector  | mappings | kubernetes nodeSelector.                                                                                                                                        |
-| subPath       | scalars  | Path of data persistence, specify the "subPath" if the PVC is shared with other components.                                                                     |
-| existingClaim | scalars  | Use the existing PVC which must be created manually before bound.                                                                                               |
-| storageClass  | scalars  | Specify the "storageClass" used to provision the volume. Or the default. StorageClass will be used(the default). Set it to "-" to disable dynamic provisioning. |
-| accessMode    | scalars  | Kubernetes Persistent Volume Access Modes: <br />ReadWriteOnce<br />ReadOnlyMany <br />ReadWriteMany.                                                           |
-| size          | scalars  | Match the volume size of PVC.                                                                                                                                   |
+| Name                     | Type     | Description                                                                                                                                                     |
+| ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| nodeSelector             | mappings | kubernetes nodeSelector.                                                                                                                                        |
+| subPath                  | scalars  | Path of data persistence, specify the "subPath" if the PVC is shared with other components.                                                                     |
+| existingClaim            | scalars  | Use the existing PVC which must be created manually before bound.                                                                                               |
+| storageClass             | scalars  | Specify the "storageClass" used to provision the volume. Or the default. StorageClass will be used(the default). Set it to "-" to disable dynamic provisioning. |
+| accessMode               | scalars  | Kubernetes Persistent Volume Access Modes: <br />ReadWriteOnce<br />ReadOnlyMany <br />ReadWriteMany.                                                           |
+| size                     | scalars  | Match the volume size of PVC.                                                                                                                                   |
+| notebook_hashed_password | scalars  | hashed password for jupyter notebook.                                                                                                                           |
 
 ### Mysql mappings
 

--- a/helm-charts/FATE/templates/core/client/statefulSet.yaml
+++ b/helm-charts/FATE/templates/core/client/statefulSet.yaml
@@ -45,8 +45,6 @@ spec:
               value: "{{.Values.modules.serving.ip}}:{{.Values.modules.serving.port}}"
             - name: NOTEBOOK_HASHED_PASSWORD
               value: {{ .Values.modules.client.notebook_hashed_password }}
-            - name: PORT
-              value: "20000"
           ports:
             - containerPort: 20000
           command: ["bash", "-c", "flow init --ip ${FATE_FLOW_IP} --port ${FATE_FLOW_PORT} && pipeline init --ip ${FATE_FLOW_IP} --port ${FATE_FLOW_PORT} && jupyter notebook --ip=0.0.0.0 --port=20000 --allow-root --debug --NotebookApp.notebook_dir='/data/projects/fate/' --no-browser --NotebookApp.token='' --NotebookApp.password=${NOTEBOOK_HASHED_PASSWORD}"]

--- a/helm-charts/FATE/templates/core/client/statefulSet.yaml
+++ b/helm-charts/FATE/templates/core/client/statefulSet.yaml
@@ -43,8 +43,13 @@ spec:
               value: "9380"
             - name: FATE_SERVING_HOST
               value: "{{.Values.modules.serving.ip}}:{{.Values.modules.serving.port}}"
+            - name: NOTEBOOK_HASHED_PASSWORD
+              value: {{ .Values.modules.client.notebook_hashed_password }}
+            - name: PORT
+              value: "20000"
           ports:
             - containerPort: 20000
+          command: ["bash", "-c", "flow init --ip ${FATE_FLOW_IP} --port ${FATE_FLOW_PORT} && pipeline init --ip ${FATE_FLOW_IP} --port ${FATE_FLOW_PORT} && jupyter notebook --ip=0.0.0.0 --port=20000 --allow-root --debug --NotebookApp.notebook_dir='/data/projects/fate/' --no-browser --NotebookApp.token='' --NotebookApp.password=${NOTEBOOK_HASHED_PASSWORD}"]
           livenessProbe:
             httpGet:
               path: /

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -233,6 +233,7 @@ skippedKeys:
   # storageClass: "client"
   # accessMode: ReadWriteOnce
   # size: 1Gi
+  # notebook_hashed_password: ""
 
 # mysql:
   # nodeSelector:

--- a/helm-charts/FATE/values-template.yaml
+++ b/helm-charts/FATE/values-template.yaml
@@ -370,6 +370,7 @@ modules:
     affinity:
 {{ toYaml . | indent 6 }}
     {{- end }}
+    notebook_hashed_password: {{ .notebook_hashed_password | default "" }}
     {{- end }}
 
 

--- a/helm-charts/FATE/values.yaml
+++ b/helm-charts/FATE/values.yaml
@@ -189,6 +189,7 @@ modules:
     storageClass:
     accessMode: ReadWriteOnce
     size: 1Gi
+    notebook_hashed_password: 
   clustermanager: 
     include: true
     ip: clustermanager


### PR DESCRIPTION
Fixes ISSUE #787

## Description
1. support setting jupyter notebook password with KubeFATE
2. everyone can visit the notebook directly as long as they can access the service, which is not secure.

## Tests
### Before fix
visit the notebook directly
### After fix
If the administrator has set a hashed password in advance, users would have to provide a password for access.

<img width="1324" alt="Screen Shot 2022-11-03 at 14 26 18" src="https://user-images.githubusercontent.com/29254314/199660769-0ad0c47b-dfc9-4662-a2e0-b889aed7d4a5.png">

Steps:
1. generate a hashed password by `from notebook.auth import passwd;passwd()`.
2. set hashed password

In docker-deploy mode, administrator can set hashed password in parties.conf
```bash
notebook_hashed_password='argon2:$argon2id$v=19$m=10240,t=10,p=8$foXXSSWQEQWESDASD'
```
In k8s-deploy mode, administrator can set hashed password in cluster.yaml -> client
```bash
client:
  notebook_hashed_password: 'argon2:$argon2id$v=19$m=10240,t=10,p=8$foXXSSWQEQWESDASD'
```

3. install cluster with KubeFATE
4. visit notebook with the original, not hashed password