### PR TITLE
Add sevice account for flow

### DIFF
--- a/helm-charts/FATE/templates/core/fateflow/rbac.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.modules.python.serviceAccountName -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -25,29 +26,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
-      - apps
+      - batch
     resources:
-      - statefulsets
-      - statefulsets/status
+      - jobs
     verbs:
+      - get
+      - list
       - create
+      - delete
       - update
       - patch
-      - list
-      - get
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - pods/log
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - ""
-    resources:
-      - pods/exec
-    verbs:
-      - create
-      - get
+{{- end -}}

--- a/helm-charts/FATE/templates/core/fateflow/rbac.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/rbac.yaml
@@ -50,3 +50,4 @@ rules:
       - pods/exec
     verbs:
       - create
+      - get

--- a/helm-charts/FATE/templates/core/fateflow/rbac.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/rbac.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flow
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flow
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flow-role
+subjects:
+  - kind: ServiceAccount
+    name: flow
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flow-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - statefulsets/status
+    verbs:
+      - create
+      - update
+      - patch
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create

--- a/helm-charts/FATE/templates/core/python-spark.yaml
+++ b/helm-charts/FATE/templates/core/python-spark.yaml
@@ -34,6 +34,7 @@ spec:
         fateMoudle: python
 {{ include "fate.labels" . | indent 8 }}
     spec:
+      serviceAccountName: flow
       {{- if .Values.istio.enabled }}
       {{- else }}
       initContainers:

--- a/helm-charts/FATE/templates/core/python-spark.yaml
+++ b/helm-charts/FATE/templates/core/python-spark.yaml
@@ -34,7 +34,6 @@ spec:
         fateMoudle: python
 {{ include "fate.labels" . | indent 8 }}
     spec:
-      serviceAccountName: flow
       {{- if .Values.istio.enabled }}
       {{- else }}
       initContainers:
@@ -195,11 +194,7 @@ spec:
       imagePullSecrets:
 {{ toYaml . | indent 6 }}
       {{- end }}
-    {{- if .Values.modules.python.serviceAccountName }}
-      serviceAccountName: {{ .Values.modules.python.serviceAccountName }}
-    {{- else }}
-      serviceAccountName: {{ template "serviceAccountName" . }}
-    {{- end }}
+      serviceAccountName: {{ .Values.modules.python.serviceAccountName | default "flow"}}
       restartPolicy: Always
       volumes:
         {{- if eq .Values.computing "Eggroll" }}


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

Fixes ISSUE #794

## Description
1. Tell the story why you need to make this change from the user's perspective.
We need to give a service account for fateflow, to let it be able to do crud for sts of the algorithm container.
We also need to give it the capability for doing exec in the algorithm container.

## Tests
### After fix
After applying the service account for fateflow, I get into the flow pod and verified below operations can work:
1. create algorithm sts.
2. check the algorithm sts status.
3. run a command in the algorithm container.
4. destroy the sts.