### PR TITLE
Fix issue 730

### DIFF
--- a/docs/configurations/FATE_cluster_configuration.md
+++ b/docs/configurations/FATE_cluster_configuration.md
@@ -153,6 +153,7 @@ The parties are directly connected.
 | nginx                       | mappings | If you use the existing nginx, you can set this configuration                                |
 | logLevel                    | scalars  | The log level of the Python process, default level is Info                                   |
 | hive                        | mappings | If you use the existing hive, you can set this configuration                                 |
+| dependent_distribution      | mappings | Distribute dependencies with spark                                                           |
 
 ### fateboard mappings
 

--- a/helm-charts/FATE/templates/core/fateflow/configmap.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/configmap.yaml
@@ -44,7 +44,7 @@ data:
   service_conf.yaml: |
     use_registry: {{ .Values.modules.serving.useRegistry | default false }}
     use_deserialize_safe_module: false
-    dependent_distribution: false
+    dependent_distribution: {{ .Values.modules.python.dependent_distribution | default false }}
     encrypt_password: false
     encrypt_module: fate_arch.common.encrypt_utils#pwdecrypt
     private_key:

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -170,6 +170,7 @@ skippedKeys:
 #   existingClaim: ""
 #   storageClass: "python"
 #   accessMode: ReadWriteMany
+#   dependent_distribution: false
 #   size: 1Gi
 #   resources:
 #     requests:

--- a/helm-charts/FATE/values-template.yaml
+++ b/helm-charts/FATE/values-template.yaml
@@ -227,6 +227,7 @@ modules:
     httpNodePort: {{ .httpNodePort }}
     grpcNodePort: {{ .grpcNodePort }}
     loadBalancerIP: {{ .loadBalancerIP }}
+    dependent_distribution: {{ .dependent_distribution }}
     serviceAccountName: {{ .serviceAccountName }}
     {{- with .nodeSelector }}
     nodeSelector: 

--- a/helm-charts/FATE/values.yaml
+++ b/helm-charts/FATE/values.yaml
@@ -134,6 +134,7 @@ modules:
     logLevel: INFO
     # subPath: ""
     existingClaim:
+    dependent_distribution: false
     claimName: python-data
     storageClass:
     accessMode: ReadWriteOnce


### PR DESCRIPTION
Fixes ISSUE #730

## Description
1. enable dependent_distribution configuration in cluster.yaml
2. add doc

## Tests
### Before fix
user has to manually modify configmap to enable dependent_distribution
### After fix
user can easy set dependent_distribution in `python` filed in cluster.yaml, like
```yaml
python:
  type: NodePort
  httpNodePort: 30107
  grpcNodePort: 30102
  logLevel: INFO
  dependent_distribution: true
```
Install cluster with the yaml, user can see in /data/projects/fate/conf/service_conf.yaml
```yaml
dependent_distribution: true
```