### PR TITLE
update docs from 1.9.0 to 1.9.1

### DIFF
--- a/docker-deploy/.env
+++ b/docker-deploy/.env
@@ -1,5 +1,5 @@
 RegistryURI=
-TAG=1.9.0-release
+TAG=1.9.1-release
 SERVING_TAG=2.1.6-release
 SSH_PORT=22
 

--- a/docker-deploy/README.md
+++ b/docker-deploy/README.md
@@ -166,12 +166,12 @@ CONTAINER ID   IMAGE                                      COMMAND               
 3dca43f3c9d5   federatedai/serving-admin:2.1.5-release    "/bin/sh -c 'java -c…"   5 minutes ago   Up 5 minutes             0.0.0.0:8350->8350/tcp, :::8350->8350/tcp                                                                                                       serving-9999_serving-admin_1
 fe924918509b   federatedai/serving-proxy:2.1.5-release    "/bin/sh -c 'java -D…"   5 minutes ago   Up 5 minutes             0.0.0.0:8059->8059/tcp, :::8059->8059/tcp, 0.0.0.0:8869->8869/tcp, :::8869->8869/tcp, 8879/tcp                                                  serving-9999_serving-proxy_1
 b62ed8ba42b7   bitnami/zookeeper:3.7.0                    "/opt/bitnami/script…"   5 minutes ago   Up 5 minutes             0.0.0.0:2181->2181/tcp, :::2181->2181/tcp, 8080/tcp, 0.0.0.0:49226->2888/tcp, :::49226->2888/tcp, 0.0.0.0:49225->3888/tcp, :::49225->3888/tcp   serving-9999_serving-zookeeper_1
-3c643324066f   federatedai/client:1.9.0-release           "/bin/sh -c 'flow in…"   5 minutes ago   Up 5 minutes             0.0.0.0:20000->20000/tcp, :::20000->20000/tcp                                                                                                   confs-9999_client_1
-3fe0af1ebd71   federatedai/fateboard:1.9.0-release        "/bin/sh -c 'java -D…"   5 minutes ago   Up 5 minutes             0.0.0.0:8080->8080/tcp, :::8080->8080/tcp                                                                                                       confs-9999_fateboard_1
-635b7d99357e   federatedai/fateflow:1.9.0-release         "container-entrypoin…"   5 minutes ago   Up 5 minutes (healthy)   0.0.0.0:9360->9360/tcp, :::9360->9360/tcp, 8080/tcp, 0.0.0.0:9380->9380/tcp, :::9380->9380/tcp                                                  confs-9999_fateflow_1
-8b515f08add3   federatedai/eggroll:1.9.0-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             8080/tcp, 0.0.0.0:9370->9370/tcp, :::9370->9370/tcp                                                                                             confs-9999_rollsite_1
-108cc061c191   federatedai/eggroll:1.9.0-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             4670/tcp, 8080/tcp                                                                                                                              confs-9999_clustermanager_1
-f10575e76899   federatedai/eggroll:1.9.0-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             4671/tcp, 8080/tcp                                                                                                                              confs-9999_nodemanager_1
+3c643324066f   federatedai/client:1.9.1-release           "/bin/sh -c 'flow in…"   5 minutes ago   Up 5 minutes             0.0.0.0:20000->20000/tcp, :::20000->20000/tcp                                                                                                   confs-9999_client_1
+3fe0af1ebd71   federatedai/fateboard:1.9.1-release        "/bin/sh -c 'java -D…"   5 minutes ago   Up 5 minutes             0.0.0.0:8080->8080/tcp, :::8080->8080/tcp                                                                                                       confs-9999_fateboard_1
+635b7d99357e   federatedai/fateflow:1.9.1-release         "container-entrypoin…"   5 minutes ago   Up 5 minutes (healthy)   0.0.0.0:9360->9360/tcp, :::9360->9360/tcp, 8080/tcp, 0.0.0.0:9380->9380/tcp, :::9380->9380/tcp                                                  confs-9999_fateflow_1
+8b515f08add3   federatedai/eggroll:1.9.1-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             8080/tcp, 0.0.0.0:9370->9370/tcp, :::9370->9370/tcp                                                                                             confs-9999_rollsite_1
+108cc061c191   federatedai/eggroll:1.9.1-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             4670/tcp, 8080/tcp                                                                                                                              confs-9999_clustermanager_1
+f10575e76899   federatedai/eggroll:1.9.1-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             4671/tcp, 8080/tcp                                                                                                                              confs-9999_nodemanager_1
 aa0a0002de93   mysql:8.0.28                               "docker-entrypoint.s…"   5 minutes ago   Up 5 minutes             3306/tcp, 33060/tcp                                                                                                                             confs-9999_mysql_1
 ```
 
@@ -360,7 +360,7 @@ cat > fateflow/examples/lr/test_hetero_lr_job_dsl.json <<EOF
       }
     },
     "dataio_0": {
-      "module": "DataIO",
+      "module": "DataTransform",
       "input": {
         "data": {
           "data": [

--- a/docker-deploy/README_zh.md
+++ b/docker-deploy/README_zh.md
@@ -185,12 +185,12 @@ CONTAINER ID   IMAGE                                      COMMAND               
 3dca43f3c9d5   federatedai/serving-admin:2.1.5-release    "/bin/sh -c 'java -c…"   5 minutes ago   Up 5 minutes             0.0.0.0:8350->8350/tcp, :::8350->8350/tcp                                                                                                       serving-9999_serving-admin_1
 fe924918509b   federatedai/serving-proxy:2.1.5-release    "/bin/sh -c 'java -D…"   5 minutes ago   Up 5 minutes             0.0.0.0:8059->8059/tcp, :::8059->8059/tcp, 0.0.0.0:8869->8869/tcp, :::8869->8869/tcp, 8879/tcp                                                  serving-9999_serving-proxy_1
 b62ed8ba42b7   bitnami/zookeeper:3.7.0                    "/opt/bitnami/script…"   5 minutes ago   Up 5 minutes             0.0.0.0:2181->2181/tcp, :::2181->2181/tcp, 8080/tcp, 0.0.0.0:49226->2888/tcp, :::49226->2888/tcp, 0.0.0.0:49225->3888/tcp, :::49225->3888/tcp   serving-9999_serving-zookeeper_1
-3c643324066f   federatedai/client:1.9.0-release           "/bin/sh -c 'flow in…"   5 minutes ago   Up 5 minutes             0.0.0.0:20000->20000/tcp, :::20000->20000/tcp                                                                                                   confs-9999_client_1
-3fe0af1ebd71   federatedai/fateboard:1.9.0-release        "/bin/sh -c 'java -D…"   5 minutes ago   Up 5 minutes             0.0.0.0:8080->8080/tcp, :::8080->8080/tcp                                                                                                       confs-9999_fateboard_1
-635b7d99357e   federatedai/fateflow:1.9.0-release         "container-entrypoin…"   5 minutes ago   Up 5 minutes (healthy)   0.0.0.0:9360->9360/tcp, :::9360->9360/tcp, 8080/tcp, 0.0.0.0:9380->9380/tcp, :::9380->9380/tcp                                                  confs-9999_fateflow_1
-8b515f08add3   federatedai/eggroll:1.9.0-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             8080/tcp, 0.0.0.0:9370->9370/tcp, :::9370->9370/tcp                                                                                             confs-9999_rollsite_1
-108cc061c191   federatedai/eggroll:1.9.0-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             4670/tcp, 8080/tcp                                                                                                                              confs-9999_clustermanager_1
-f10575e76899   federatedai/eggroll:1.9.0-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             4671/tcp, 8080/tcp                                                                                                                              confs-9999_nodemanager_1
+3c643324066f   federatedai/client:1.9.1-release           "/bin/sh -c 'flow in…"   5 minutes ago   Up 5 minutes             0.0.0.0:20000->20000/tcp, :::20000->20000/tcp                                                                                                   confs-9999_client_1
+3fe0af1ebd71   federatedai/fateboard:1.9.1-release        "/bin/sh -c 'java -D…"   5 minutes ago   Up 5 minutes             0.0.0.0:8080->8080/tcp, :::8080->8080/tcp                                                                                                       confs-9999_fateboard_1
+635b7d99357e   federatedai/fateflow:1.9.1-release         "container-entrypoin…"   5 minutes ago   Up 5 minutes (healthy)   0.0.0.0:9360->9360/tcp, :::9360->9360/tcp, 8080/tcp, 0.0.0.0:9380->9380/tcp, :::9380->9380/tcp                                                  confs-9999_fateflow_1
+8b515f08add3   federatedai/eggroll:1.9.1-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             8080/tcp, 0.0.0.0:9370->9370/tcp, :::9370->9370/tcp                                                                                             confs-9999_rollsite_1
+108cc061c191   federatedai/eggroll:1.9.1-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             4670/tcp, 8080/tcp                                                                                                                              confs-9999_clustermanager_1
+f10575e76899   federatedai/eggroll:1.9.1-release          "/tini -- bash -c 'j…"   5 minutes ago   Up 5 minutes             4671/tcp, 8080/tcp                                                                                                                              confs-9999_nodemanager_1
 aa0a0002de93   mysql:8.0.28                               "docker-entrypoint.s…"   5 minutes ago   Up 5 minutes             3306/tcp, 33060/tcp                                                                                                                             confs-9999_mysql_1
 ```
 
@@ -382,7 +382,7 @@ cat > fateflow/examples/lr/test_hetero_lr_job_dsl.json <<EOF
       }
     },
     "dataio_0": {
-      "module": "DataIO",
+      "module": "DataTransform",
       "input": {
         "data": {
           "data": [

--- a/docs/Customize_KubeFATE_Chart.md
+++ b/docs/Customize_KubeFATE_Chart.md
@@ -28,7 +28,7 @@ Unzip one KubeFATE's Chart, you can find a `templates` folder and 4 files:
 ## `templates` folder
 In `templates` folder, the template yaml file combined with values will generate valid Kubernetes manifest files for each `FATE` or `FATE-Serving` component.
 
-e.g. For `FATE` v1.9.0, there are following templates locating in `template` folder:
+e.g. For `FATE` v1.9.1, there are following templates locating in `template` folder:
 1. eggroll: eggroll module, including 3 eggroll related components: clustermanager, nodemanager and rollsite/lb-rollsite.
 2. spark: spark module, including spark, hdfs, nginx, pulsar/rabbitmq. People just need to pick one module from spark and eggroll.
 3. client: the module for the jupyter notebook client.

--- a/docs/Eggroll_with_TLS.md
+++ b/docs/Eggroll_with_TLS.md
@@ -146,7 +146,7 @@ Then in the cluster.yaml file of FATE-Exchange, turn on the ```enableTLS``` swit
 
 ## Docker-Compose mode
 
-In KubeFATE release v1.91, we will not provide a switch for enabling TLS for rollsite. This can be done in below manual steps:
+In KubeFATE release v1.9.1, we will not provide a switch for enabling TLS for rollsite. This can be done in below manual steps:
 
 1. Generate the certs, as above documents shows, for every FATE cluster and for the FATE Exchange if needed.
 2. Run `docker ps` to get the container id of the rollsite.

--- a/docs/Eggroll_with_TLS.md
+++ b/docs/Eggroll_with_TLS.md
@@ -146,7 +146,7 @@ Then in the cluster.yaml file of FATE-Exchange, turn on the ```enableTLS``` swit
 
 ## Docker-Compose mode
 
-In KubeFATE release v1.9.0, we will not provide a switch for enabling TLS for rollsite. This can be done in below manual steps:
+In KubeFATE release v1.91, we will not provide a switch for enabling TLS for rollsite. This can be done in below manual steps:
 
 1. Generate the certs, as above documents shows, for every FATE cluster and for the FATE Exchange if needed.
 2. Run `docker ps` to get the container id of the rollsite.

--- a/docs/Manage_FATE_and_FATE-Serving_Version.md
+++ b/docs/Manage_FATE_and_FATE-Serving_Version.md
@@ -30,18 +30,18 @@ The chart can be downloaded in each KubeFATE release, with name `fate-{release_v
 
 Download it and copy it to the folder to upload.
 ```
-$ kubefate chart upload -f ./fate-v1.9.0.tgz
+$ kubefate chart upload -f ./fate-v1.9.1.tgz
 Upload file success
 
 $ kubefate chart ls
 UUID                                    NAME    VERSION        APPVERSION
-ca3f7843-749a-4f69-9f6b-4c544a7623ac    fate    v1.9.0         v1.9.0
+ca3f7843-749a-4f69-9f6b-4c544a7623ac    fate    v1.9.1         v1.9.1
 ```
 
-Then, we can deploy the fate cluster of v1.9.0 version. The detail of cluster.yaml please refer to: [FATE Cluster Configuration](./configurations/FATE_cluster_configuration.md)
+Then, we can deploy the fate cluster of v1.9.1 version. The detail of cluster.yaml please refer to: [FATE Cluster Configuration](./configurations/FATE_cluster_configuration.md)
 ```
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 ```
 
 We can delete the chart with:

--- a/docs/tutorials/Build_Two_Parties_FATE_Cluster_in_One_Linux_Machine_with_MiniKube.md
+++ b/docs/tutorials/Build_Two_Parties_FATE_Cluster_in_One_Linux_Machine_with_MiniKube.md
@@ -21,14 +21,14 @@ After the tutorial, the deployment architecture looks like the following diagram
 5. Network connectivity to dockerhub or 163 Docker Image Registry, and google gcr.
 6. Setup the global KubeFATE version using in the tutorial and create a folder for the whole tutorial.
 ```
-export fate_version=v1.9.0 && export kubefate_version=v1.4.5 && cd ~ && mkdir demo && cd demo
+export fate_version=v1.9.1 && export kubefate_version=v1.4.5 && cd ~ && mkdir demo && cd demo
 ```
 
 Notes:
 * When talking about KubeFATE version, usually there are 3 notions:
    * The KubeFATE CLI version, in this tutorial, it is v1.4.5.
    * The KubeFATE service version, in this tutorial, it is v1.4.5.
-   * The FATE version, in this tutorial, it is v1.9.0, it also means the version of the helm chart of FATE, currently we use this version to tag the KubeFATE GitHub master branch.
+   * The FATE version, in this tutorial, it is v1.9.1, it also means the version of the helm chart of FATE, currently we use this version to tag the KubeFATE GitHub master branch.
 * **<font color="red">In this tutorial, the IP of the machine we used is 192.168.100.123. Please change it to your machine's IP in all the following commands and config files.</font></div>**
 
 # Start Tutorial
@@ -87,7 +87,7 @@ When all the pods are in the ready state, it means your Kubernetes cluster is re
 ## Setup Kubefate
 ### Install KubeFATE CLI
 Go to [KubeFATE Release](https://github.com/FederatedAI/KubeFATE/releases), and find the latest kubefate-k8s release 
-pack, which is `v1.9.0` as set to ENVs before. (replace ${fate_version} with the newest version available)
+pack, which is `v1.9.1` as set to ENVs before. (replace ${fate_version} with the newest version available)
 ```
 curl -LO https://github.com/FederatedAI/KubeFATE/releases/download/${fate_version}/kubefate-k8s-${fate_version}.tar.gz && tar -xzf ./kubefate-k8s-${fate_version}.tar.gz
 ```
@@ -256,7 +256,7 @@ For `/kubefate/examples/party-9999/cluster-spark-pulsar.yaml`, modify it as foll
 name: fate-9999
 namespace: fate-9999
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 9999
 registry: ""
 pullPolicy:
@@ -340,7 +340,7 @@ and for fate-10000:
 name: fate-10000
 namespace: fate-10000
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 10000
 registry: ""
 pullPolicy:
@@ -440,8 +440,8 @@ or watch the clusters till their STATUS changing to `Running`:
 ```
 kubefate@machine:~/kubefate$ watch kubefate cluster ls
 UUID                                    NAME            NAMESPACE       REVISION        STATUS  CHART   ChartVERSION    AGE
-29878fa9-aeee-4ae5-a5b7-fd4e9eb7c1c3    fate-9999       fate-9999       1               Running fate    v1.9.0          88s
-dacc0549-b9fc-463f-837a-4e7316db2537    fate-10000      fate-10000      1               Running fate    v1.9.0          69s
+29878fa9-aeee-4ae5-a5b7-fd4e9eb7c1c3    fate-9999       fate-9999       1               Running fate    v1.9.1          88s
+dacc0549-b9fc-463f-837a-4e7316db2537    fate-10000      fate-10000      1               Running fate    v1.9.1          69s
 ```
 We have about 10G Docker images that need to be pulled, this step will take a while for the first time.
 An alternative way is offline loading the images to the local environment.
@@ -479,13 +479,13 @@ UUID        	29878fa9-aeee-4ae5-a5b7-fd4e9eb7c1c3
 Name        	fate-9999
 NameSpace   	fate-9999
 ChartName   	fate
-ChartVersion	v1.9.0
+ChartVersion	v1.9.1
 Revision    	1
 Age         	54m
 Status      	Running
 Spec        	algorithm: Basic
             	chartName: fate
-            	chartVersion: v1.9.0
+            	chartVersion: v1.9.1
             	computing: Spark
             	device: CPU
             	federation: Pulsar

--- a/docs/tutorials/Build_Two_Parties_FATE_Cluster_in_One_Linux_Machine_with_MiniKube_zh.md
+++ b/docs/tutorials/Build_Two_Parties_FATE_Cluster_in_One_Linux_Machine_with_MiniKube_zh.md
@@ -17,14 +17,14 @@
 5. 要保证安装机器可以正常访问Docker Hub或者网易云镜像仓库，以及Google gcr； 
 6. 预先创建一个目录，以便整个过程使用该目录作为工作目录，命令如下：
 ```
-export fate_version=v1.9.0 && export kubefate_version=v1.4.5 && cd ~ && mkdir demo && cd demo
+export fate_version=v1.9.1 && export kubefate_version=v1.4.5 && cd ~ && mkdir demo && cd demo
 ```
 
 Notes:
 * 当我们提到"KubeFATE的版本"，通常来讲会有三个概念：
     * KubeFATE命令行工具的版本，在本教程中为v1.4.5。
     * KubeFATE服务版本，在本教程中为v1.4.5。
-    * FATE版本，在本教程中v1.9.0，它也意味着FATE的Helm Chart的版本, 值得注意的是我们用这个版本来给GitHub上的KubeFATE的发布打tag。
+    * FATE版本，在本教程中v1.9.1，它也意味着FATE的Helm Chart的版本, 值得注意的是我们用这个版本来给GitHub上的KubeFATE的发布打tag。
 * **<font color="red">下文介绍的MiniKube机器IP地址是192.168.100.123。请修改为你准备的实验机器IP地址</font></div>**
 
 # 开始安装
@@ -77,7 +77,7 @@ sudo minikube addons enable ingress
 
 ## 安装Kubefate
 ### 下载KubeFATE命令行工具
-我们从Github上 [KubeFATE Release](https://github.com/FederatedAI/KubeFATE/releases)页面找到Kuberetes部署的下载包，并下载对应版本，如前面环境变量设置`v1.9.0`，
+我们从Github上 [KubeFATE Release](https://github.com/FederatedAI/KubeFATE/releases)页面找到Kuberetes部署的下载包，并下载对应版本，如前面环境变量设置`v1.9.1`，
 ```
 curl -LO https://github.com/FederatedAI/KubeFATE/releases/download/${fate_version}/kubefate-k8s-${fate_version}.tar.gz && tar -xzf ./kubefate-k8s-${fate_version}.tar.gz
 ```
@@ -237,7 +237,7 @@ kubectl -n fate-10000 create secret docker-registry myregistrykey \
 name: fate-9999
 namespace: fate-9999
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 9999
 registry: ""
 pullPolicy:
@@ -322,7 +322,7 @@ pulsar:
 name: fate-10000
 namespace: fate-10000
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 10000
 registry: ""
 pullPolicy:
@@ -418,8 +418,8 @@ create job success, job id=7752db70-e368-41fa-8827-d39411728d1b
 ```
 kubefate@machine:~/kubefate$ watch kubefate cluster ls
 UUID                                    NAME            NAMESPACE       REVISION        STATUS  CHART   ChartVERSION    AGE
-29878fa9-aeee-4ae5-a5b7-fd4e9eb7c1c3    fate-9999       fate-9999       1               Running fate    v1.9.0          88s
-dacc0549-b9fc-463f-837a-4e7316db2537    fate-10000      fate-10000      1               Running fate    v1.9.0          69s
+29878fa9-aeee-4ae5-a5b7-fd4e9eb7c1c3    fate-9999       fate-9999       1               Running fate    v1.9.1          88s
+dacc0549-b9fc-463f-837a-4e7316db2537    fate-10000      fate-10000      1               Running fate    v1.9.1          69s
 ```
 因为这个步骤需要到网易云镜像仓库去下载约10G的镜像，所以第一次执行视乎你的网络情况需要一定时间。
 检查下载的进度可以用
@@ -446,13 +446,13 @@ UUID        	29878fa9-aeee-4ae5-a5b7-fd4e9eb7c1c3
 Name        	fate-9999
 NameSpace   	fate-9999
 ChartName   	fate
-ChartVersion	v1.9.0
+ChartVersion	v1.9.1
 Revision    	1
 Age         	54m
 Status      	Running
 Spec        	algorithm: Basic
             	chartName: fate
-            	chartVersion: v1.9.0
+            	chartVersion: v1.9.1
             	computing: Spark
             	device: CPU
             	federation: Pulsar

--- a/helm-charts/FATE-Exchange/Chart.yaml
+++ b/helm-charts/FATE-Exchange/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.9.0
+appVersion: v1.9.1
 description: A Helm chart for fate exchange
 name: fate-exchange
-version: v1.9.0
+version: v1.9.1

--- a/helm-charts/FATE-Exchange/values-template-example.yaml
+++ b/helm-charts/FATE-Exchange/values-template-example.yaml
@@ -1,7 +1,7 @@
 name: fate-exchange
 namespace: fate-exchange
 chartName: fate-exchange
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 1
 registry: ""
 imagePullSecrets: 

--- a/helm-charts/FATE-Exchange/values.yaml
+++ b/helm-charts/FATE-Exchange/values.yaml
@@ -4,7 +4,7 @@ partyName: fate-exchange
 image:
   registry: federatedai
   isThridParty:
-  tag: 1.9.0-release
+  tag: 1.9.1-release
   pullPolicy: IfNotPresent
   imagePullSecrets: 
 #  - name: 

--- a/helm-charts/FATE/Chart.yaml
+++ b/helm-charts/FATE/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v1.9.0
+appVersion: v1.9.1
 description: A Helm chart for fate-training
 name: fate
-version: v1.9.0
+version: v1.9.1
 home: https://fate.fedai.org
 icon: https://aisp-1251170195.cos.ap-hongkong.myqcloud.com/wp-content/uploads/sites/12/2019/09/logo.png
 sources:

--- a/helm-charts/FATE/values-template-example.yaml
+++ b/helm-charts/FATE/values-template-example.yaml
@@ -1,7 +1,7 @@
 name: fate-9999
 namespace: fate-9999
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 9999
 registry: ""
 pullPolicy: 

--- a/helm-charts/FATE/values.yaml
+++ b/helm-charts/FATE/values.yaml
@@ -2,7 +2,7 @@
 image:
   registry: federatedai
   isThridParty:
-  tag: 1.9.0-release
+  tag: 1.9.1-release
   pullPolicy: IfNotPresent
   imagePullSecrets: 
 #  - name: 

--- a/helm-charts/UpgradeManager/values.yaml
+++ b/helm-charts/UpgradeManager/values.yaml
@@ -1,4 +1,4 @@
 username: fate
 password: fate_dev
-start: 1.9.0
-target: 1.9.0
+start: 1.9.1
+target: 1.9.1

--- a/k8s-deploy/README.md
+++ b/k8s-deploy/README.md
@@ -186,13 +186,13 @@ UUID         24bb75ff-f636-4c64-8c04-1b9073f89a2f
 Name         fate-9999                           
 NameSpace    fate-9999                           
 ChartName    fate                                
-ChartVersion v1.9.0                              
+ChartVersion v1.9.1                              
 Revision     1                                   
 Age          15m                                 
 Status       Running                             
 Spec         algorithm: Basic                    
              chartName: fate                     
-             chartVersion: v1.9.0                
+             chartVersion: v1.9.1                
              computing: Eggroll                  
              device: CPU                         
              federation: Eggroll                 

--- a/k8s-deploy/README_zh.md
+++ b/k8s-deploy/README_zh.md
@@ -185,13 +185,13 @@ UUID         24bb75ff-f636-4c64-8c04-1b9073f89a2f
 Name         fate-9999                           
 NameSpace    fate-9999                           
 ChartName    fate                                
-ChartVersion v1.9.0                              
+ChartVersion v1.9.1                              
 Revision     1                                   
 Age          15m                                 
 Status       Running                             
 Spec         algorithm: Basic                    
              chartName: fate                     
-             chartVersion: v1.9.0                
+             chartVersion: v1.9.1                
              computing: Eggroll                  
              device: CPU                         
              federation: Eggroll                 

--- a/k8s-deploy/cluster-spark-pulsar.yaml
+++ b/k8s-deploy/cluster-spark-pulsar.yaml
@@ -1,7 +1,7 @@
 name: fate-9999
 namespace: fate-9999
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 9999
 registry: ""
 pullPolicy:

--- a/k8s-deploy/cluster-spark-rabbitmq.yaml
+++ b/k8s-deploy/cluster-spark-rabbitmq.yaml
@@ -1,7 +1,7 @@
 name: fate-9999
 namespace: fate-9999
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 9999
 registry: ""
 pullPolicy:

--- a/k8s-deploy/cluster-spark-slim.yaml
+++ b/k8s-deploy/cluster-spark-slim.yaml
@@ -1,7 +1,7 @@
 name: fate-9999
 namespace: fate-9999
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 9999
 registry: ""
 pullPolicy:

--- a/k8s-deploy/cluster.yaml
+++ b/k8s-deploy/cluster.yaml
@@ -1,7 +1,7 @@
 name: fate-9999
 namespace: fate-9999
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 9999
 registry: ""
 pullPolicy:

--- a/k8s-deploy/examples/party-10000/cluster-spark-local-pulsar.yaml
+++ b/k8s-deploy/examples/party-10000/cluster-spark-local-pulsar.yaml
@@ -1,7 +1,7 @@
 name: fate-10000
 namespace: fate-10000
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 10000
 registry: ""
 pullPolicy:

--- a/k8s-deploy/examples/party-10000/cluster-spark-pulsar.yaml
+++ b/k8s-deploy/examples/party-10000/cluster-spark-pulsar.yaml
@@ -1,7 +1,7 @@
 name: fate-10000
 namespace: fate-10000
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 10000
 registry: ""
 pullPolicy:

--- a/k8s-deploy/examples/party-10000/cluster-spark-rabbitmq.yaml
+++ b/k8s-deploy/examples/party-10000/cluster-spark-rabbitmq.yaml
@@ -1,7 +1,7 @@
 name: fate-10000
 namespace: fate-10000
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 10000
 registry: ""
 pullPolicy:

--- a/k8s-deploy/examples/party-10000/cluster.yaml
+++ b/k8s-deploy/examples/party-10000/cluster.yaml
@@ -1,7 +1,7 @@
 name: fate-10000
 namespace: fate-10000
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 10000
 registry: ""
 pullPolicy:

--- a/k8s-deploy/examples/party-9999/cluster-spark-local-pulsar.yaml
+++ b/k8s-deploy/examples/party-9999/cluster-spark-local-pulsar.yaml
@@ -1,7 +1,7 @@
 name: fate-9999
 namespace: fate-9999
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 9999
 registry: ""
 pullPolicy:

--- a/k8s-deploy/examples/party-9999/cluster-spark-pulsar.yaml
+++ b/k8s-deploy/examples/party-9999/cluster-spark-pulsar.yaml
@@ -1,7 +1,7 @@
 name: fate-9999
 namespace: fate-9999
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 9999
 registry: ""
 pullPolicy:

--- a/k8s-deploy/examples/party-9999/cluster-spark-rabbitmq.yaml
+++ b/k8s-deploy/examples/party-9999/cluster-spark-rabbitmq.yaml
@@ -1,7 +1,7 @@
 name: fate-9999
 namespace: fate-9999
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 9999
 registry: ""
 pullPolicy:

--- a/k8s-deploy/examples/party-9999/cluster.yaml
+++ b/k8s-deploy/examples/party-9999/cluster.yaml
@@ -1,7 +1,7 @@
 name: fate-9999
 namespace: fate-9999
 chartName: fate
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 9999
 registry: ""
 pullPolicy:

--- a/k8s-deploy/examples/party-exchange/rollsite.yaml
+++ b/k8s-deploy/examples/party-exchange/rollsite.yaml
@@ -1,7 +1,7 @@
 name: fate-exchange
 namespace: fate-exchange
 chartName: fate-exchange
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 1
 registry: ""
 pullPolicy:

--- a/k8s-deploy/examples/party-exchange/trafficServer.yaml
+++ b/k8s-deploy/examples/party-exchange/trafficServer.yaml
@@ -1,7 +1,7 @@
 name: fate-exchange
 namespace: fate-exchange
 chartName: fate-exchange
-chartVersion: v1.9.0
+chartVersion: v1.9.1
 partyId: 1
 registry: ""
 pullPolicy:

--- a/k8s-deploy/examples/party.config
+++ b/k8s-deploy/examples/party.config
@@ -1,5 +1,5 @@
-fate_chartVersion=v1.9.0
-fate_imageTAG=1.9.0-release
+fate_chartVersion=v1.9.1
+fate_imageTAG=1.9.1-release
 fate_serving_chartVersion=v2.1.6
 fate_serving_imageTAG=2.1.6-release
 party_9999_IP=192.168.9.1

--- a/k8s-deploy/pkg/job/fate_upgrade_manager.go
+++ b/k8s-deploy/pkg/job/fate_upgrade_manager.go
@@ -102,19 +102,24 @@ func (fum *FateUpgradeManager) waitFinish(interval, round int) bool {
 }
 
 func getMysqlCredFromSpec(clusterSpec modules.MapStringInterface) (username, password string) {
+	defaultUsername := "fate"
+	defaultPassword := "fate_dev"
+	if clusterSpec["mysql"] == nil {
+	   return defaultUsername, defaultPassword
+	}
 	mysqlSpec := clusterSpec["mysql"].(map[string]interface{})
 	if mysqlSpec["user"] == nil {
-		username = "fate"
+	   username = defaultUsername
 	} else {
-		username = mysqlSpec["user"].(string)
+	   username = mysqlSpec["user"].(string)
 	}
 	if mysqlSpec["password"] == nil {
-		password = "fate_dev"
+	   password = defaultPassword
 	} else {
-		password = mysqlSpec["password"].(string)
+	   password = mysqlSpec["password"].(string)
 	}
 	return
-}
+ }
 
 func constructFumSpec(oldSpec, newSpec modules.MapStringInterface) (fumSpec modules.MapStringInterface) {
 	oldVersion := strings.ReplaceAll(oldSpec["chartVersion"].(string), "v", "")

--- a/k8s-deploy/pkg/modules/helm_chart.go
+++ b/k8s-deploy/pkg/modules/helm_chart.go
@@ -27,7 +27,7 @@ import (
 // HelmChart Helm Chart model
 type HelmChart struct {
 	Uuid                  string    `json:"uuid" gorm:"type:varchar(36);index;unique"`
-	Name                  string    `json:"name" gorm:"type:varchar(16);not null"`
+	Name                  string    `json:"name" gorm:"type:varchar(36);not null"`
 	Chart                 string    `json:"chart" gorm:"type:text;not null"`
 	Values                string    `json:"values" gorm:"type:text;not null"`
 	ValuesTemplate        string    `json:"values_template" gorm:"type:text;not null"`


### PR DESCRIPTION
Signed-off-by: hang lv <xlv20@fudan.edu.cn>

## Description
1. updated docs from 1.9.0 to 1.9.1
2. changed deprecated api used in tutorial

## Tests
### Before fix
serving tutorial command`flow job submit -d fateflow/examples/lr/test_hetero_lr_job_dsl.json -c fateflow/examples/lr/test_hetero_lr_job_conf.json` would fail, and output
`ValueError: In Fate-v1.9 or later version, DataIO is deprecated, use DataTransform instead.`

### After fix
I changed DataIO to DataTransform, then task ran successfully.