### PR TITLE
fix the issue which leads to fum fail

### DIFF
--- a/helm-charts/UpgradeManager/templates/rbac.yaml
+++ b/helm-charts/UpgradeManager/templates/rbac.yaml
@@ -30,6 +30,7 @@ rules:
   - deployments
   - deployments/status
   - statefulsets
+  - statefulsets/status
   verbs:
   - update
   - patch

--- a/k8s-deploy/rbac-config.yaml
+++ b/k8s-deploy/rbac-config.yaml
@@ -90,6 +90,8 @@ rules:
   resources:
   - deployments
   - statefulsets
+  - deployments/status
+  - statefulsets/status
   verbs:
   - get
   - list
@@ -141,3 +143,14 @@ rules:
   - delete
   - update
   - patch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+  verbs:
+    - get
+    - list
+    - create
+    - delete
+    - update
+    - patch


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

## Description
Without this fix upgrade will fail

## Tests
### Before fix

Using fum to upgrade from v1.9.0 to v1.9.1 will fail.

### After fix

Using fum to upgrade from v1.9.0 to v1.9.1 can succee.