### PR TITLE
add the read authorities to pod for the flow SA

### DIFF
--- a/helm-charts/FATE/templates/core/fateflow/rbac.yaml
+++ b/helm-charts/FATE/templates/core/fateflow/rbac.yaml
@@ -36,4 +36,12 @@ rules:
       - delete
       - update
       - patch
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/status
+    verbs:
+      - get
+      - list
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

Need this change because we need to read the exit code of the procedure in the pod.

Have been tested.