### PR TITLE
kubefate cluster installation with correct fateflow python-0 pv size …

### DIFF
--- a/helm-charts/FATE/templates/core/python-spark.yaml
+++ b/helm-charts/FATE/templates/core/python-spark.yaml
@@ -238,6 +238,6 @@ spec:
         storageClassName: {{ .Values.modules.python.storageClass }}
         resources:
           requests:
-            storage: {{ .Values.modules.mysql.size }}
+            storage: {{ .Values.modules.python.size }}
         {{- end }}
 {{- end }}


### PR DESCRIPTION
…setting. issue #859

Fixes ISSUE #859 

## Description
To correctly set the fateflow PV from the cluser.yaml without bounding mysql PV setting.