### PR TITLE
Fix kubefate push actions "This request was automatically failed beca…

### DIFF
--- a/.github/workflows/kubefate-push.yml
+++ b/.github/workflows/kubefate-push.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   # no test is required
   push:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push'
 
     steps:


### PR DESCRIPTION
…use there were no enabled runners online to process the request for more than 1 days."

Fixes Actions https://github.com/FederatedAI/KubeFATE/actions/runs/4932035872

## Description

This action failed because `runs-on: ubuntu-18.04` has been deprecated.

[The Ubuntu 18.04 Actions runner image will begin deprecation on 2022/08/08 and will be fully unsupported by 2023/04/03](https://github.com/actions/runner-images/issues/6002)

## Solution

Change `ubuntu-18.04` to `ubuntu-22.04`