### PR TITLE
Update README.md

### DIFF
--- a/docker-deploy/README.md
+++ b/docker-deploy/README.md
@@ -197,7 +197,7 @@ aa0a0002de93   mysql:8.0.28                               "docker-entrypoint.sâ€
 On the target node of each party, a container named  `confs-<party_id>_fateflow_1` should have been created and running the `fate-flow` service. For example, on Party 10000's node, run the following commands to verify the deployment:
 
 ```bash
-docker exec -it confs-10000_client_1 bash
+docker exec -it confs-10000-client-1 bash
 flow test toy --guest-party-id 10000 --host-party-id 9999
 ```
 


### PR DESCRIPTION
在文档示例中 docker exec -it confs-10000_client_1 bash   命令错误，根据实际部署情况发现 docker 的容器名为 confs-10000-client-1

## Description
fix: README.md fate-client docker containerName err change to confs-10000-client-1


![image](https://github.com/FederatedAI/KubeFATE/assets/40063899/0d916548-18d8-46d9-98fb-a80a447ff8fc)